### PR TITLE
Organize measures into a JSON file and generate a Full OSW with all measures in rakefile

### DIFF
--- a/resources/measure-order.json
+++ b/resources/measure-order.json
@@ -1,0 +1,517 @@
+[
+  {
+    "group_name": "1. Location",
+    "steps": [
+      {
+        "name": "1. Location",
+        "dependencies": "",
+        "measures": [
+          "ResidentialLocation"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "2. Geometry",
+    "steps": [
+      {
+        "name": "1. Geometry Single-Family Detached (or Single-Family Attached or Multifamily)",
+        "dependencies": "",
+        "measures": [
+          "ResidentialGeometrySingleFamilyDetached",
+          "ResidentialGeometrySingleFamilyAttached",
+          "ResidentialGeometryMultifamily"
+        ]
+      },
+      {
+        "name": "2. Number of Beds and Baths",
+        "dependencies": "",
+        "measures": [
+          "ResidentialGeometryNumBedsAndBaths"
+        ]
+      },
+      {
+        "name": "3. Number of Occupants",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialGeometryNumOccupants"
+        ]
+      },
+      {
+        "name": "4. Orientation",
+        "dependencies": "",
+        "measures": [
+          "ResidentialGeometryOrientation"
+        ]
+      },
+      {
+        "name": "5. Eaves",
+        "dependencies": "",
+        "measures": [
+          "ResidentialGeometryEaves"
+        ]
+      },
+      {
+        "name": "6. Door Area",
+        "dependencies": "",
+        "measures": [
+          "ResidentialGeometryDoorArea"
+        ]
+      },
+      {
+        "name": "7. Window Areas",
+        "dependencies": "",
+        "measures": [
+          "ResidentialGeometryWindowArea"
+        ]
+      },
+      {
+        "name": "8. Overhangs",
+        "dependencies": "Window Areas",
+        "measures": [
+          "ResidentialGeometryOverhangs"
+        ]
+      },
+      {
+        "name": "9. Neighbors",
+        "dependencies": "",
+        "measures": [
+          "ResidentialGeometryNeighbors"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "3. Envelope Constructions",
+    "steps": [
+      {
+        "name": "1. Ceilings/Roofs - Unfinished Attic Constructions (or Finished Roof)",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsCeilingsRoofsUnfinishedAttic",
+          "ResidentialConstructionsCeilingsRoofsFinishedRoof"
+        ]
+      },
+      {
+        "name": "2. Ceilings/Roofs - Roof Sheathing",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsCeilingsRoofsSheathing"
+        ]
+      },
+      {
+        "name": "3. Ceilings/Roofs - Roofing Material",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsCeilingsRoofsRoofingMaterial"
+        ]
+      },
+      {
+        "name": "4. Ceilings/Roofs - Radiant Barrier",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsCeilingsRoofsRadiantBarrier"
+        ]
+      },
+      {
+        "name": "5. Ceilings/Roofs - Ceiling Thermal Mass",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsCeilingsRoofsThermalMass"
+        ]
+      },
+      {
+        "name": "6. Foundations/Floors - Unfinished Basement Construction (or Finished Basement, Crawlspace, Slab, or Pier & Beam)",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsFoundationsFloorsBasementUnfinished",
+          "ResidentialConstructionsFoundationsFloorsBasementFinished",
+          "ResidentialConstructionsFoundationsFloorsCrawlspace",
+          "ResidentialConstructionsFoundationsFloorsPierBeam",
+          "ResidentialConstructionsFoundationsFloorsSlab"
+        ]
+      },
+      {
+        "name": "7. Foundations/Floors - Interzonal Floor Construction",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsFoundationsFloorsInterzonalFloors"
+        ]
+      },
+      {
+        "name": "8. Foundations/Floors - Floor Covering",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsFoundationsFloorsCovering"
+        ]
+      },
+      {
+        "name": "9. Foundations/Floors - Floor Sheathing",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsFoundationsFloorsSheathing"
+        ]
+      },
+      {
+        "name": "10. Foundations/Floors - Floor Thermal Mass",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsFoundationsFloorsThermalMass"
+        ]
+      },
+      {
+        "name": "11. Walls - Wood Stud Construction (or Double Stud, CMU, etc.)",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsWallsExteriorWoodStud",
+          "ResidentialConstructionsWallsExteriorDoubleWoodStud",
+          "ResidentialConstructionsWallsExteriorSteelStud",
+          "ResidentialConstructionsWallsExteriorCMU",
+          "ResidentialConstructionsWallsExteriorICF",
+          "ResidentialConstructionsWallsExteriorSIP",
+          "ResidentialConstructionsWallsExteriorGeneric"
+        ]
+      },
+      {
+        "name": "12. Walls - Interzonal Construction",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsWallsInterzonal"
+        ]
+      },
+      {
+        "name": "13. Walls - Wall Sheathing",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsWallsSheathing"
+        ]
+      },
+      {
+        "name": "14. Walls - Exterior Finish",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsWallsExteriorFinish"
+        ]
+      },
+      {
+        "name": "15. Walls - Exterior Thermal Mass",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsWallsExteriorThermalMass"
+        ]
+      },
+      {
+        "name": "16. Walls - Partition Thermal Mass",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsWallsPartitionThermalMass"
+        ]
+      },
+      {
+        "name": "17. Uninsulated Surfaces",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsUninsulatedSurfaces"
+        ]
+      },
+      {
+        "name": "18. Window Construction",
+        "dependencies": "Window Areas, Location",
+        "measures": [
+          "ResidentialConstructionsWindows"
+        ]
+      },
+      {
+        "name": "19. Door Construction",
+        "dependencies": "Door Area",
+        "measures": [
+          "ResidentialConstructionsDoors"
+        ]
+      },
+      {
+        "name": "20. Furniture Thermal Mass",
+        "dependencies": "",
+        "measures": [
+          "ResidentialConstructionsFurnitureThermalMass"
+        ]
+      }
+    ]
+  }, 
+  {
+    "group_name": "4. Domestic Hot Water",
+    "steps": [
+      {
+        "name": "1. Water Heater (Electric Tank, Fuel Tankless, etc.)",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialHotWaterHeaterHeatPump",
+          "ResidentialHotWaterHeaterTankElectric",
+          "ResidentialHotWaterHeaterTankFuel",
+          "ResidentialHotWaterHeaterTanklessElectric",
+          "ResidentialHotWaterHeaterTanklessFuel"
+        ]
+      },
+      {
+        "name": "2. Hot Water Fixtures",
+        "dependencies": "Water Heater",
+        "measures": [
+          "ResidentialHotWaterFixtures"
+        ]
+      },
+      {
+        "name": "3. Hot Water Distribution",
+        "dependencies": "Hot Water Fixtures, Location",
+        "measures": [
+          "ResidentialHotWaterDistribution"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "5. HVAC",
+    "steps": [
+      {
+        "name": "1. Central Air Conditioner and Furnace (or ASHP, Boiler, MSHP, etc.)",
+        "dependencies": "",
+        "measures": [
+          "ResidentialHVACCentralAirConditionerSingleSpeed", 
+          "ResidentialHVACAirSourceHeatPumpSingleSpeed",     
+          "ResidentialHVACAirSourceHeatPumpTwoSpeed",
+          "ResidentialHVACAirSourceHeatPumpVariableSpeed",
+          "ResidentialHVACBoilerElectric",
+          "ResidentialHVACBoilerFuel",
+          "ResidentialHVACCentralAirConditionerTwoSpeed",
+          "ResidentialHVACCentralAirConditionerVariableSpeed",
+          "ResidentialHVACDehumidifier",
+          "ResidentialHVACElectricBaseboard",
+          "ResidentialHVACFurnaceElectric",
+          "ResidentialHVACFurnaceFuel",
+          "ResidentialHVACGroundSourceHeatPumpVerticalBore",
+          "ResidentialHVACMiniSplitHeatPump",
+          "ResidentialHVACRoomAirConditioner"
+        ]
+      },
+      {
+        "name": "2. Heating Setpoint",
+        "dependencies": "HVAC Equipment, Location",
+        "measures": [
+          "ResidentialHVACHeatingSetpoints"
+        ]
+      },
+      {
+        "name": "3. Cooling Setpoint",
+        "dependencies": "HVAC Equipment, Location",
+        "measures": [
+          "ResidentialHVACCoolingSetpoints"
+        ]
+      },
+      {
+        "name": "4. Ceiling Fan",
+        "dependencies": "Cooling Setpoint, Beds/Baths",
+        "measures": [
+          "ResidentialHVACCeilingFan"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "6. Major Appliances",
+    "steps": [
+      {
+        "name": "1. Refrigerator",
+        "dependencies": "",
+        "measures": [
+          "ResidentialApplianceRefrigerator"
+        ]
+      },
+      {
+        "name": "2. Clothes Washer",
+        "dependencies": "Water Heater, Location",
+        "measures": [
+          "ResidentialApplianceClothesWasher"
+        ]
+      },
+      {
+        "name": "3. Clothes Dryer (Electric or Fuel)",
+        "dependencies": "Beds/Baths, Clothes Washer",
+        "measures": [
+          "ResidentialApplianceClothesDryerElectric",
+          "ResidentialApplianceClothesDryerFuel"
+        ]
+      },
+      {
+        "name": "4. Dishwasher",
+        "dependencies": "Water Heater, Location",
+        "measures": [
+          "ResidentialApplianceDishwasher"
+        ]
+      },
+      {
+        "name": "5. Cooking Range (Electric or Fuel)",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialApplianceCookingRangeElectric",
+          "ResidentialApplianceCookingRangeFuel"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "7. Lighting",
+    "steps": [
+      {
+        "name": "1. Lighting",
+        "dependencies": "Location",
+        "measures": [
+          "ResidentialLighting"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "8. Misc Loads",
+    "steps": [
+      {
+        "name": "1. Plug Loads",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscPlugLoads"
+        ]
+      },
+      {
+        "name": "2. Extra Refrigerator",
+        "dependencies": "",
+        "measures": [
+          "ResidentialMiscExtraRefrigerator"
+        ]
+      },
+      {
+        "name": "3. Freezer",
+        "dependencies": "",
+        "measures": [
+          "ResidentialMiscFreezer"
+        ]
+      },
+      {
+        "name": "4. Hot Tub Heater (Electric or Gas)",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscHotTubHeaterElectric",
+          "ResidentialMiscHotTubHeaterGas"
+        ]
+      },
+      {
+        "name": "5. Hot Tub Pump",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscHotTubPump"
+        ]
+      },
+      {
+        "name": "6. Pool Heater (Electric or Gas)",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscPoolHeaterElectric",
+          "ResidentialMiscPoolHeaterGas"
+        ]
+      },
+      {
+        "name": "7. Pool Pump",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscPoolPump"
+        ]
+      },
+      {
+        "name": "8. Well Pump",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscWellPump"
+        ]
+      },
+      {
+        "name": "9. Gas Fireplace",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscGasFireplace"
+        ]
+      },
+      {
+        "name": "10. Gas Grill",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscGasGrill"
+        ]
+      },
+      {
+        "name": "11. Gas Lighting",
+        "dependencies": "Beds/Baths",
+        "measures": [
+          "ResidentialMiscGasLighting"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "9. Airflow",
+    "steps": [
+      {
+        "name": "1. Airflow",
+        "dependencies": "Location, Beds/Baths, HVAC Equipment, Clothes Dryer",
+        "measures": [
+          "ResidentialAirflow"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "10. Sizing",
+    "steps": [
+      {
+        "name": "1. HVAC Sizing",
+        "dependencies": "(lots of measures...)",
+        "measures": [
+          "ResidentialHVACSizing"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "11. Renewables",
+    "steps": [
+      {
+        "name": "1. Photovoltaics",
+        "dependencies": "Geometry",
+        "measures": [
+          "ResidentialPhotovoltaics"
+        ]
+      }
+    ]
+  },
+  {
+    "group_name": "Other",
+    "steps": [
+      {
+        "name": "Full workflow from HPXML",
+        "dependencies": "",
+        "measures": [
+          "HPXMLBuildModel"
+        ]
+      },
+      {
+        "name": "TimeseriesCSVExport",
+        "dependencies": "",
+        "measures": [
+          "TimeseriesCSVExport"
+        ]
+      },
+      {
+        "name": "UtilityBillCalculations",
+        "dependencies": "",
+        "measures": [
+          "UtilityBillCalculations"
+        ]
+      }
+    ]
+  }
+]

--- a/test/osw_files/FullJSON.osw
+++ b/test/osw_files/FullJSON.osw
@@ -1,0 +1,1524 @@
+{
+   "created_at" : "20170413T132904Z",
+   "measure_paths" : [ "../../measures" ],
+   "seed_file" : "../../seeds/EmptySeedModel.osm",
+   "steps" : [
+      {
+         "arguments" : {
+            "dst_end_date" : "October 26",
+            "dst_start_date" : "April 7",
+            "weather_directory" : "./resources",
+            "weather_file_name" : "USA_CO_Denver_Intl_AP_725650_TMY3.epw"
+         },
+         "description" : "Sets the EPW weather file (EPW), supplemental data specific to the location, and daylight saving time start/end dates.",
+         "measure_dir_name" : "ResidentialLocation",
+         "modeler_description" : "[ModelMeasure] Sets the weather file, Building America climate zone, site information (e.g., latitude, longitude, elevation, timezone), design day information (from the DDY file), the mains water temperature using the correlation method, and the daylight saving time start/end dates.",
+         "name" : "Set Residential Location"
+      },
+      {
+         "arguments" : {
+            "aspect_ratio" : 2,
+            "attic_type" : "unfinished attic",
+            "foundation_height" : 3,
+            "foundation_type" : "slab",
+            "garage_depth" : 20,
+            "garage_pos" : "Right",
+            "garage_protrusion" : 0,
+            "garage_width" : 0,
+            "living_height" : 8,
+            "num_floors" : 2,
+            "roof_pitch" : "6:12",
+            "roof_type" : "gable",
+            "total_ffa" : 2000
+         },
+         "description" : "Sets the basic geometry for the building. Building is limited to one foundation type. Garage is tucked within the building, on the front left or front right corners of the building.",
+         "measure_dir_name" : "ResidentialGeometrySingleFamilyDetached",
+         "modeler_description" : "[ModelMeasure] Gathers living space area, wall height per floor, number of floors, aspect ratio, garage width and depth, garage position, foundation type and wall height, attic and roof type, and roof pitch. Constructs building by calculating footprint and performing a series of affine transformations into living, foundation, and attic spaces.",
+         "name" : "Create Residential Single-Family Detached Geometry"
+      },
+      {
+         "arguments" : {
+            "attic_type" : "unfinished attic",
+            "building_num_floors" : 1,
+            "foundation_height" : 3,
+            "foundation_type" : "slab",
+            "has_rear_units" : false,
+            "living_height" : 8,
+            "num_units" : 2,
+            "offset" : 0,
+            "roof_pitch" : "6:12",
+            "roof_type" : "gable",
+            "unit_aspect_ratio" : 2,
+            "unit_ffa" : 900,
+            "use_zone_mult" : false
+         },
+         "description" : "Sets the basic geometry for the building.",
+         "measure_dir_name" : "ResidentialGeometrySingleFamilyAttached",
+         "modeler_description" : "[ModelMeasure] Creates single-family attached geometry.",
+         "name" : "Create Residential Single-Family Attached Geometry"
+      },
+      {
+         "arguments" : {
+            "balc_depth" : 0,
+            "building_num_floors" : 1,
+            "corr_pos" : "Double-Loaded Interior",
+            "corr_width" : 10,
+            "foundation_height" : 3,
+            "foundation_type" : "slab",
+            "inset_depth" : 0,
+            "inset_pos" : "Right",
+            "inset_width" : 0,
+            "living_height" : 8,
+            "num_units_per_floor" : 2,
+            "unit_aspect_ratio" : 2,
+            "unit_ffa" : 900,
+            "use_floor_mult" : false,
+            "use_zone_mult" : false
+         },
+         "description" : "Sets the basic geometry for the building.",
+         "measure_dir_name" : "ResidentialGeometryMultifamily",
+         "modeler_description" : "[ModelMeasure] Creates multifamily geometry.",
+         "name" : "Create Residential Multifamily Geometry"
+      },
+      {
+         "arguments" : {
+            "num_bathrooms" : "2",
+            "num_bedrooms" : "3"
+         },
+         "description" : "Sets the number of bedrooms and bathrooms in the building. For multifamily buildings, the bedrooms/bathrooms can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialGeometryNumBedsAndBaths",
+         "modeler_description" : "[ModelMeasure] Sets (or replaces) dummy ElectricEquipment objects that store the number of bedrooms and bathrooms associated with the model.",
+         "name" : "Set Residential Number of Beds and Baths"
+      },
+      {
+         "arguments" : {
+            "monthly_sch" : "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0",
+            "num_occ" : "auto",
+            "weekday_sch" : "1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 0.88310, 0.40861, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.29498, 0.55310, 0.89693, 0.89693, 0.89693, 1.00000, 1.00000, 1.00000",
+            "weekend_sch" : "1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 1.00000, 0.88310, 0.40861, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.24189, 0.29498, 0.55310, 0.89693, 0.89693, 0.89693, 1.00000, 1.00000, 1.00000"
+         },
+         "description" : "Sets the number of occupants in the building. For multifamily buildings, the people can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialGeometryNumOccupants",
+         "modeler_description" : "[ModelMeasure] Sets (or replaces) the People object for each finished space in the model.",
+         "name" : "Set Residential Number of Occupants"
+      },
+      {
+         "arguments" : {
+            "orientation" : 180
+         },
+         "description" : "Sets the fixed orientation of the building.",
+         "measure_dir_name" : "ResidentialGeometryOrientation",
+         "modeler_description" : "[ModelMeasure] Modifies the North axis of the building.",
+         "name" : "Set Residential Orientation"
+      },
+      {
+         "arguments" : {
+            "eaves_depth" : 2,
+            "roof_structure" : "truss, cantilever"
+         },
+         "description" : "Sets the eaves for the building.",
+         "measure_dir_name" : "ResidentialGeometryEaves",
+         "modeler_description" : "[ModelMeasure] Performs a series of affine transformations on the roof decks into shading surfaces.",
+         "name" : "Set Residential Eaves"
+      },
+      {
+         "arguments" : {
+            "door_area" : 20
+         },
+         "description" : "Sets the opaque door area for the building. Doors with glazing should be set as window area. For multifamily buildings, door area can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialGeometryDoorArea",
+         "modeler_description" : "[ModelMeasure] Sets the opaque door area for the lowest above-grade front surface attached to living space. Any existing doors are removed. For multifamily buildings, doors are placed on corridor walls if available.",
+         "name" : "Set Residential Door Area"
+      },
+      {
+         "arguments" : {
+            "aspect_ratio" : 1.333,
+            "back_wwr" : 0.17999999999999999,
+            "front_wwr" : 0.17999999999999999,
+            "left_wwr" : 0.17999999999999999,
+            "right_wwr" : 0.17999999999999999
+         },
+         "description" : "Sets the window area for the building. Doors with glazing should be set as window area.",
+         "measure_dir_name" : "ResidentialGeometryWindowArea",
+         "modeler_description" : "[ModelMeasure] Automatically creates and positions standard residential windows based on the specified window area on each building facade. Windows are only added to surfaces between finished space and outside. Any existing windows are removed.",
+         "name" : "Set Residential Window Area"
+      },
+      {
+         "arguments" : {
+            "back_facade" : true,
+            "depth" : 2,
+            "front_facade" : true,
+            "left_facade" : true,
+            "offset" : 0.5,
+            "right_facade" : true
+         },
+         "description" : "Sets presence/dimensions of overhangs for windows on the specified building facade(s).",
+         "measure_dir_name" : "ResidentialGeometryOverhangs",
+         "modeler_description" : "[ModelMeasure] Creates overhang shading surfaces for windows on the specified building facade(s) and specified depth/offset. Any existing overhang shading surfaces are removed.",
+         "name" : "Set Residential Overhangs"
+      },
+      {
+         "arguments" : {
+            "back_offset" : 0,
+            "front_offset" : 0,
+            "left_offset" : 10,
+            "right_offset" : 10
+         },
+         "description" : "Sets the neighbors (front, back, left, and/or right) of the building for shading purposes. Neighboring buildings will have the same geometry as the model building.",
+         "measure_dir_name" : "ResidentialGeometryNeighbors",
+         "modeler_description" : "[ModelMeasure] Creates shading surfaces by shifting the building's exterior surfaces in the specified directions (front, back, left, and/or right).",
+         "name" : "Set Residential Neighbors"
+      },
+      {
+         "arguments" : {
+            "ceil_ff" : 0.070000000000000007,
+            "ceil_grade" : "I",
+            "ceil_ins_thick_in" : 8.5500000000000007,
+            "ceil_joist_height" : 3.5,
+            "ceil_r" : 30,
+            "roof_cavity_grade" : "I",
+            "roof_cavity_ins_thick_in" : 0,
+            "roof_cavity_r" : 0,
+            "roof_ff" : 0.070000000000000007,
+            "roof_fram_thick_in" : 7.25
+         },
+         "description" : "This measure assigns constructions to unfinished attic floors and ceilings.",
+         "measure_dir_name" : "ResidentialConstructionsCeilingsRoofsUnfinishedAttic",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of constructions for 1) floors between unfinished space under a roof and finished space and 2) roofs of unfinished space.",
+         "name" : "Set Residential Ceilings/Roofs - Unfinished Attic Constructions"
+      },
+      {
+         "arguments" : {
+            "cavity_depth" : 9.25,
+            "cavity_r" : 30,
+            "framing_factor" : 0.070000000000000007,
+            "ins_fills_cavity" : false,
+            "install_grade" : "I"
+         },
+         "description" : "This measure assigns a construction to finished roofs.",
+         "measure_dir_name" : "ResidentialConstructionsCeilingsRoofsFinishedRoof",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of finished constructions for roofs above finished space.",
+         "name" : "Set Residential Ceilings/Roofs - Finished Roof Construction"
+      },
+      {
+         "arguments" : {
+            "osb_thick_in" : 0.75,
+            "rigid_r" : 0,
+            "rigid_thick_in" : 0
+         },
+         "description" : "This measure assigns roof sheathing to all attic roofs.",
+         "measure_dir_name" : "ResidentialConstructionsCeilingsRoofsSheathing",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for all attic roofs.",
+         "name" : "Set Residential Ceilings/Roofs - Roof Sheathing"
+      },
+      {
+         "arguments" : {
+            "color" : "medium",
+            "emissivity" : 0.91000000000000003,
+            "material" : "asphalt shingles",
+            "solar_abs" : 0.84999999999999998
+         },
+         "description" : "This measure assigns the roofing material to all roof surfaces.",
+         "measure_dir_name" : "ResidentialConstructionsCeilingsRoofsRoofingMaterial",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for all roofceiling surfaces adjacent to outside.",
+         "name" : "Set Residential Ceilings/Roofs - Roofing Material"
+      },
+      {
+         "arguments" : {
+            "has_rb" : false
+         },
+         "description" : "This measure assigns the radiant barrier material to all roof surfaces attached to unfinished space.",
+         "measure_dir_name" : "ResidentialConstructionsCeilingsRoofsRadiantBarrier",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for all roofceiling surfaces adjacent to outside that are not attached to unfinished space.",
+         "name" : "Set Residential Ceilings/Roofs - Radiant Barrier"
+      },
+      {
+         "arguments" : {
+            "cond1" : 1.1112,
+            "cond2" : "Optional - Conductivity of the second layer. Leave blank if no second layer.",
+            "dens1" : 50,
+            "dens2" : "Optional - Density of the second layer. Leave blank if no second layer.",
+            "specheat1" : 0.20000000000000001,
+            "specheat2" : "Optional - Specific heat of the second layer. Leave blank if no second layer.",
+            "thick_in1" : 0.5,
+            "thick_in2" : "Optional - Thickness of the second layer. Leave blank if no second layer."
+         },
+         "description" : "This measure assigns thermal mass to ceilings adjacent to finished space.",
+         "measure_dir_name" : "ResidentialConstructionsCeilingsRoofsThermalMass",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for ceilings adjacent to finished space.",
+         "name" : "Set Residential Ceilings/Roofs - Ceiling Thermal Mass"
+      },
+      {
+         "arguments" : {
+            "ceil_cavity_grade" : "I",
+            "ceil_cavity_r" : 0,
+            "ceil_ff" : 0.13,
+            "ceil_joist_height" : 9.25,
+            "exposed_perim" : "auto",
+            "wall_cavity_depth" : 0,
+            "wall_cavity_grade" : "I",
+            "wall_cavity_insfills" : false,
+            "wall_cavity_r" : 0,
+            "wall_ff" : 0,
+            "wall_ins_height" : 8,
+            "wall_rigid_r" : 10,
+            "wall_rigid_thick_in" : 2
+         },
+         "description" : "This measure assigns constructions to the unfinished basement ceilings, walls, and floors.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsBasementUnfinished",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of constructions for: 1) ceilings above below-grade unfinished space, 2) walls between below-grade unfinished space and ground, and 3) floors below below-grade unfinished space. Below-grade spaces are assumed to be basements (and not crawlspaces) if the space height is greater than or equal to 7 ft.",
+         "name" : "Set Residential Foundations/Floors - Unfinished Basement Constructions"
+      },
+      {
+         "arguments" : {
+            "ceil_ff" : 0.13,
+            "ceil_joist_height" : 9.25,
+            "exposed_perim" : "auto",
+            "wall_cavity_depth" : 0,
+            "wall_cavity_grade" : "I",
+            "wall_cavity_insfills" : false,
+            "wall_cavity_r" : 0,
+            "wall_ff" : 0,
+            "wall_ins_height" : 8,
+            "wall_rigid_r" : 10,
+            "wall_rigid_thick_in" : 2
+         },
+         "description" : "This measure assigns constructions to finished basement walls and floors.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsBasementFinished",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of constructions for: 1) walls between below-grade finished space and ground, and 2) floors below below-grade finished space. Below-grade spaces are assumed to be basements (and not crawlspaces) if the space height is greater than or equal to 7 ft.",
+         "name" : "Set Residential Foundations/Floors - Finished Basement Constructions"
+      },
+      {
+         "arguments" : {
+            "ceil_cavity_grade" : "I",
+            "ceil_cavity_r" : 0,
+            "ceil_ff" : 0.13,
+            "ceil_joist_height" : 9.25,
+            "exposed_perim" : "auto",
+            "wall_rigid_r" : 10,
+            "wall_rigid_thick_in" : 2
+         },
+         "description" : "This measure assigns constructions to the crawlspace ceilings, walls, and floors.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsCrawlspace",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of constructions for: 1) ceilings above below-grade unfinished space, 2) walls between below-grade unfinished space and ground, and 3) floors below below-grade unfinished space. Below-grade spaces are assumed to be crawlspaces (and not basements) if the space height is less than 7 ft.",
+         "name" : "Set Residential Foundations/Floors - Crawlspace Constructions"
+      },
+      {
+         "arguments" : {
+            "cavity_r" : 19,
+            "framing_factor" : 0.13,
+            "install_grade" : "I"
+         },
+         "description" : "This measure assigns a wood stud construction to the ceiling of the pier & beam space.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsPierBeam",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for floors finished space and pier & beam space. If the floors have an existing construction, the layers (other than floor covering and floor mass) are replaced. This measure is intended to be used in conjunction with Floor Covering and Floor Mass measures.",
+         "name" : "Set Residential Foundations/Floors - Pier & Beam Construction"
+      },
+      {
+         "arguments" : {
+            "exposed_perim" : "auto",
+            "ext_depth" : 0,
+            "ext_r" : 0,
+            "gap_r" : 0,
+            "mass_conductivity" : 9.0999999999999996,
+            "mass_density" : 140,
+            "mass_specific_heat" : 0.20000000000000001,
+            "mass_thick_in" : 4,
+            "perim_r" : 0,
+            "perim_width" : 0,
+            "whole_r" : 0
+         },
+         "description" : "This measure assigns a construction to slabs-on-grade.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsSlab",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of slab constructions for floors between above-grade finished space and the ground.",
+         "name" : "Set Residential Foundations/Floors - Slab Construction"
+      },
+      {
+         "arguments" : {
+            "cavity_r" : 19,
+            "framing_factor" : 0.13,
+            "install_grade" : "I"
+         },
+         "description" : "This measure assigns a wood stud construction to floors between finished space and unfinished space or floors below cantilevered finished space.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsInterzonalFloors",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for floors 1) between finished and unfinished spaces or 2) between finished spaces and outside. If the floors have an existing construction, the layers (other than floor covering and floor mass) are replaced. This measure is intended to be used in conjunction with Floor Covering and Floor Mass measures.",
+         "name" : "Set Residential Foundations/Floors - Interzonal Floor Construction"
+      },
+      {
+         "arguments" : {
+            "covering_frac" : 0.80000000000000004,
+            "covering_r" : 2.0800000000000001
+         },
+         "description" : "This measure assigns a covering to floors of above-grade finished spaces.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsCovering",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for floors of above-grade finished spaces.",
+         "name" : "Set Residential Foundations/Floors - Floor Covering"
+      },
+      {
+         "arguments" : {
+            "osb_thick_in" : 0.75,
+            "rigid_r" : 0,
+            "rigid_thick_in" : 0
+         },
+         "description" : "This measure assigns floor sheathing to floors of finished spaces, with the exception of foundation slabs.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsSheathing",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for floors of finished spaces that are not adjacent to the ground.",
+         "name" : "Set Residential Foundations/Floors - Floor Sheathing"
+      },
+      {
+         "arguments" : {
+            "cond" : 0.8004,
+            "dens" : 34,
+            "specheat" : 0.28999999999999998,
+            "thick_in" : 0.625
+         },
+         "description" : "This measure assigns floor mass to floors of finished spaces, with the exception of foundation slabs.",
+         "measure_dir_name" : "ResidentialConstructionsFoundationsFloorsThermalMass",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for floors of finished spaces that are not adjacent to the ground.",
+         "name" : "Set Residential Foundations/Floors - Floor Thermal Mass"
+      },
+      {
+         "arguments" : {
+            "cavity_depth" : 3.5,
+            "cavity_r" : 13,
+            "framing_factor" : 0.25,
+            "ins_fills_cavity" : true,
+            "install_grade" : "I"
+         },
+         "description" : "This measure assigns a wood stud construction to above-grade exterior walls adjacent to finished space or attic walls under insulated roofs.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorWoodStud",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for 1) above-grade walls between finished space and outside, and 2) above-grade walls between attics under insulated roofs and outside. If the walls have an existing construction, the layers (other than exterior finish, wall sheathing, and wall mass) are replaced. This measure is intended to be used in conjunction with Exterior Finish, Wall Sheathing, and Exterior Wall Mass measures.",
+         "name" : "Set Residential Walls - Wood Stud Construction"
+      },
+      {
+         "arguments" : {
+            "cavity_r" : 33,
+            "framing_factor" : 0.22,
+            "framing_spacing" : 24,
+            "gap_depth" : 3.5,
+            "install_grade" : "I",
+            "is_staggered" : false,
+            "stud_depth" : 3.5
+         },
+         "description" : "This measure assigns a double wood stud construction to above-grade exterior walls adjacent to finished space or attic walls under insulated roofs.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorDoubleWoodStud",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for 1) above-grade walls between finished space and outside, and 2) above-grade walls between attics under insulated roofs and outside. If the walls have an existing construction, the layers (other than exterior finish, wall sheathing, and wall mass) are replaced. This measure is intended to be used in conjunction with Exterior Finish, Wall Sheathing, and Exterior Wall Mass measures.",
+         "name" : "Set Residential Walls - Double Wood Stud Construction"
+      },
+      {
+         "arguments" : {
+            "cavity_depth" : 3.5,
+            "cavity_r" : 13,
+            "correction_factor" : 0.46000000000000002,
+            "framing_factor" : 0.25,
+            "ins_fills_cavity" : true,
+            "install_grade" : "I"
+         },
+         "description" : "This measure assigns a steel stud construction to above-grade exterior walls adjacent to finished space or attic walls under insulated roofs.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorSteelStud",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for 1) above-grade walls between finished space and outside, and 2) above-grade walls between attics under insulated roofs and outside. If the walls have an existing construction, the layers (other than exterior finish, wall sheathing, and wall mass) are replaced. This measure is intended to be used in conjunction with Exterior Finish, Wall Sheathing, and Exterior Wall Mass measures.",
+         "name" : "Set Residential Walls - Steel Stud Construction"
+      },
+      {
+         "arguments" : {
+            "conductivity" : 5.3300000000000001,
+            "density" : 119,
+            "framing_factor" : 0.075999999999999998,
+            "furring_cavity_depth" : 1,
+            "furring_r" : 0,
+            "furring_spacing" : 24,
+            "thickness" : 6
+         },
+         "description" : "This measure assigns a CMU construction to above-grade exterior walls adjacent to finished space or attic walls under insulated roofs.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorCMU",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for 1) above-grade walls between finished space and outside, and 2) above-grade walls between attics under insulated roofs and outside. If the walls have an existing construction, the layers (other than exterior finish, wall sheathing, and wall mass) are replaced. This measure is intended to be used in conjunction with Exterior Finish, Wall Sheathing, and Exterior Wall Mass measures.",
+         "name" : "Set Residential Walls - CMU Construction"
+      },
+      {
+         "arguments" : {
+            "concrete_thick_in" : 4,
+            "framing_factor" : 0.075999999999999998,
+            "icf_r" : 10,
+            "ins_thick_in" : 2
+         },
+         "description" : "This measure assigns an ICF construction to above-grade exterior walls adjacent to finished space or attic walls under insulated roofs.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorICF",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for 1) above-grade walls between finished space and outside, and 2) above-grade walls between attics under insulated roofs and outside. If the walls have an existing construction, the layers (other than exterior finish, wall sheathing, and wall mass) are replaced. This measure is intended to be used in conjunction with Exterior Finish, Wall Sheathing, and Exterior Wall Mass measures.",
+         "name" : "Set Residential Walls - ICF Construction"
+      },
+      {
+         "arguments" : {
+            "framing_factor" : 0.156,
+            "sheathing_thick_in" : 0.44,
+            "sheathing_type" : "osb",
+            "sip_r" : 17.5,
+            "thick_in" : 3.625
+         },
+         "description" : "This measure assigns a SIP construction to above-grade exterior walls adjacent to finished space or attic walls under insulated roofs.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorSIP",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for 1) above-grade walls between finished space and outside, and 2) above-grade walls between attics under insulated roofs and outside. If the walls have an existing construction, the layers (other than exterior finish, wall sheathing, and wall mass) are replaced. This measure is intended to be used in conjunction with Exterior Finish, Wall Sheathing, and Exterior Wall Mass measures.",
+         "name" : "Set Residential Walls - SIP Construction"
+      },
+      {
+         "arguments" : {
+            "conductivity_1" : 9.2110000000000003,
+            "conductivity_2" : "Optional - Conductivity of the second layer. Leave blank if no second layer.",
+            "conductivity_3" : "Optional - Conductivity of the third layer. Leave blank if no third layer.",
+            "conductivity_4" : "Optional - Conductivity of the fourth layer. Leave blank if no fourth layer.",
+            "conductivity_5" : "Optional - Conductivity of the fifth layer. Leave blank if no fifth layer.",
+            "density_1" : 138.33000000000001,
+            "density_2" : "Optional - Density of the second layer. Leave blank if no second layer.",
+            "density_3" : "Optional - Density of the third layer. Leave blank if no third layer.",
+            "density_4" : "Optional - Density of the fourth layer. Leave blank if no fourth layer.",
+            "density_5" : "Optional - Density of the fifth layer. Leave blank if no fifth layer.",
+            "specific_heat_1" : 0.23000000000000001,
+            "specific_heat_2" : "Optional - Specific heat of the second layer. Leave blank if no second layer.",
+            "specific_heat_3" : "Optional - Specific heat of the third layer. Leave blank if no third layer.",
+            "specific_heat_4" : "Optional - Specific heat of the fourth layer. Leave blank if no fourth layer.",
+            "specific_heat_5" : "Optional - Specific heat of the fifth layer. Leave blank if no fifth layer.",
+            "thick_in_1" : 2.5,
+            "thick_in_2" : "Optional - Thickness of the second layer. Leave blank if no second layer.",
+            "thick_in_3" : "Optional - Thickness of the third layer. Leave blank if no third layer.",
+            "thick_in_4" : "Optional - Thickness of the fourth layer. Leave blank if no fourth layer.",
+            "thick_in_5" : "Optional - Thickness of the fifth layer. Leave blank if no fifth layer."
+         },
+         "description" : "This measure assigns a generic layered construction to above-grade exterior walls adjacent to finished space or attic walls under insulated roofs.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorGeneric",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for 1) above-grade walls between finished space and outside, and 2) above-grade walls between attics under insulated roofs and outside. If the walls have an existing construction, the layers (other than exterior finish, wall sheathing, and wall mass) are replaced. This measure is intended to be used in conjunction with Exterior Finish, Wall Sheathing, and Exterior Wall Mass measures.",
+         "name" : "Set Residential Walls - Generic Construction"
+      },
+      {
+         "arguments" : {
+            "cavity_depth" : 3.5,
+            "cavity_r" : 13,
+            "framing_factor" : 0.25,
+            "ins_fills_cavity" : true,
+            "install_grade" : "I"
+         },
+         "description" : "This measure assigns a wood stud construction to walls between finished space and unfinished space.",
+         "measure_dir_name" : "ResidentialConstructionsWallsInterzonal",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of wood stud constructions for walls between finished and unfinished spaces. If the walls have an existing construction, the layers (other than wall sheathing and partition wall mass) are replaced. This measure is intended to be used in conjunction with Wall Sheathing and Partition Wall Mass measures.",
+         "name" : "Set Residential Walls - Interzonal Construction"
+      },
+      {
+         "arguments" : {
+            "osb_thick_in" : 0.5,
+            "rigid_r" : 0,
+            "rigid_thick_in" : 0
+         },
+         "description" : "This measure assigns wall sheathing to all above-grade walls adjacent to finished space.",
+         "measure_dir_name" : "ResidentialConstructionsWallsSheathing",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for all above-grade walls between finished space and outside or between finished space and unfinished space.",
+         "name" : "Set Residential Walls - Wall Sheathing"
+      },
+      {
+         "arguments" : {
+            "conductivity" : 0.62,
+            "density" : 11.1,
+            "emissivity" : 0.90000000000000002,
+            "solar_abs" : 0.29999999999999999,
+            "specific_heat" : 0.25,
+            "thick_in" : 0.375
+         },
+         "description" : "This measure assigns the exterior finish to all above-grade exterior walls.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorFinish",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for all above-grade walls adjacent to outside.",
+         "name" : "Set Residential Walls - Exterior Finish"
+      },
+      {
+         "arguments" : {
+            "cond1" : 1.1112,
+            "cond2" : "Optional - Conductivity of the second layer. Leave blank if no second layer.",
+            "dens1" : 50,
+            "dens2" : "Optional - Density of the second layer. Leave blank if no second layer.",
+            "specheat1" : 0.20000000000000001,
+            "specheat2" : "Optional - Specific heat of the second layer. Leave blank if no second layer.",
+            "thick_in1" : 0.5,
+            "thick_in2" : "Optional - Thickness of the second layer. Leave blank if no second layer."
+         },
+         "description" : "This measure assigns wall mass to above-grade exterior walls adjacent to finished space.",
+         "measure_dir_name" : "ResidentialConstructionsWallsExteriorThermalMass",
+         "modeler_description" : "[ModelMeasure] Assigns material layer properties for above-grade walls between finished space and outside.",
+         "name" : "Set Residential Walls - Exterior Thermal Mass"
+      },
+      {
+         "arguments" : {
+            "cond1" : 1.1112,
+            "cond2" : "Optional - Conductivity of the second layer. Leave blank if no second layer.",
+            "dens1" : 50,
+            "dens2" : "Optional - Density of the second layer. Leave blank if no second layer.",
+            "frac" : 1,
+            "specheat1" : 0.20000000000000001,
+            "specheat2" : "Optional - Specific heat of the second layer. Leave blank if no second layer.",
+            "thick_in1" : 0.5,
+            "thick_in2" : "Optional - Thickness of the second layer. Leave blank if no second layer."
+         },
+         "description" : "This measure assigns partition wall mass to finished spaces.",
+         "measure_dir_name" : "ResidentialConstructionsWallsPartitionThermalMass",
+         "modeler_description" : "[ModelMeasure] This measure creates constructions representing the internal mass of partition walls for finished spaces. The constructions are set to define the internal mass objects of their respective spaces.",
+         "name" : "Set Residential Walls - Partition Thermal Mass"
+      },
+      {
+         "arguments" : {},
+         "description" : "This measure assigns an uninsulated constructions to 1) exterior surfaces adjacent to unfinished space, 2) surfaces between two unfinished (or two finished) spaces, or 3) adiabatic surfaces.",
+         "measure_dir_name" : "ResidentialConstructionsUninsulatedSurfaces",
+         "modeler_description" : "[ModelMeasure] Calculates and assigns material layer properties of uninsulated constructions for surfaces that are not typically insulated.",
+         "name" : "Set Residential Uninsulated Surfaces"
+      },
+      {
+         "arguments" : {
+            "cooling_shade_mult" : 0.69999999999999996,
+            "heating_shade_mult" : 0.69999999999999996,
+            "shgc" : 0.29999999999999999,
+            "ufactor" : 0.37
+         },
+         "description" : "This measure assigns a construction to windows. This measure also creates the interior shading schedule, which is based on shade multipliers and the heating and cooling season logic defined in the Building America House Simulation Protocols.",
+         "measure_dir_name" : "ResidentialConstructionsWindows",
+         "modeler_description" : "[ModelMeasure] Calculates material layer properties of constructions for windows. Finds sub surfaces and sets applicable constructions. Using interior heating and cooling shading multipliers and the Building America heating and cooling season logic, creates schedule rulesets for window shade and shading control.",
+         "name" : "Set Residential Window Construction"
+      },
+      {
+         "arguments" : {
+            "door_uvalue" : 0.20000000000000001
+         },
+         "description" : "This measure assigns a construction to exterior doors adjacent to finished or unfinished space.",
+         "measure_dir_name" : "ResidentialConstructionsDoors",
+         "modeler_description" : "[ModelMeasure] Calculates material layer properties of constructions for exterior door sub-surfaces adjacent to 1) finished space or 2) unfinished space.",
+         "name" : "Set Residential Door Construction"
+      },
+      {
+         "arguments" : {
+            "area_fraction" : 0.40000000000000002,
+            "conductivity" : 0.8004,
+            "density" : 40,
+            "mass" : 8,
+            "solar_abs" : 0.59999999999999998,
+            "specific_heat" : 0.28999999999999998
+         },
+         "description" : "Adds (or replaces) furniture mass to finished and unfinished spaces.",
+         "measure_dir_name" : "ResidentialConstructionsFurnitureThermalMass",
+         "modeler_description" : "[ModelMeasure] This measure creates constructions representing the internal mass of furniture in finished and unfinished spaces. If existing furniture mass objects are found, they are removed.",
+         "name" : "Set Residential Furniture Thermal Mass"
+      },
+      {
+         "arguments" : {
+            "airflow_rate" : 181,
+            "cap" : 1.3999999999999999,
+            "cop" : 2.7999999999999998,
+            "dhw_setpoint_temperature" : 125,
+            "element_capacity" : 4.5,
+            "fan_power" : 0.046199999999999998,
+            "int_factor" : 1,
+            "max_temp" : 120,
+            "min_temp" : 45,
+            "parasitics" : 3,
+            "shr" : 0.88,
+            "space" : "auto",
+            "storage_tank_volume" : 50,
+            "tank_ua" : 3.8999999999999999,
+            "temp_depress" : 0
+         },
+         "description" : "This measure adds a new residential heat pump water heater to the model based on user inputs. If there is already an existing residential water heater in the model, it is replaced. For multifamily buildings, the water heater can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHotWaterHeaterHeatPump",
+         "modeler_description" : "[ModelMeasure] The measure will create a new instance of the OS:WaterHeater:HeatPump:WrappedCondenser object representing a heat pump water heater and EMS code for the controls. The water heater will be placed on the plant loop 'Domestic Hot Water Loop'. If this loop already exists, any water heater on that loop will be removed and replaced with a water heater consistent with this measure. If it doesn't exist, it will be created.",
+         "name" : "Set Residential Heat Pump Water Heater"
+      },
+      {
+         "arguments" : {
+            "capacity" : "4.5",
+            "energy_factor" : "0.92",
+            "location" : "auto",
+            "setpoint_temp" : 125,
+            "tank_volume" : "auto"
+         },
+         "description" : "This measure adds a new residential electric storage water heater to the model based on user inputs. If there is already an existing residential water heater in the model, it is replaced. For multifamily buildings, the water heater can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHotWaterHeaterTankElectric",
+         "modeler_description" : "[ModelMeasure] The measure will create a new instance of the OS:WaterHeater:Mixed object representing an electric storage water heater. The water heater will be placed on the plant loop 'Domestic Hot Water Loop'. If this loop already exists, any water heater on that loop will be removed and replaced with a water heater consistent with this measure. If it doesn't exist, it will be created.",
+         "name" : "Set Residential Electric Tank Water Heater"
+      },
+      {
+         "arguments" : {
+            "capacity" : "40.0",
+            "energy_factor" : "0.59",
+            "fuel_type" : "gas",
+            "location" : "auto",
+            "offcyc_power" : 0,
+            "oncyc_power" : 0,
+            "recovery_efficiency" : 0.76000000000000001,
+            "setpoint_temp" : 125,
+            "tank_volume" : "auto"
+         },
+         "description" : "This measure adds a new residential fuel storage water heater to the model based on user inputs. If there is already an existing residential water heater in the model, it is replaced. For multifamily buildings, the water heater can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHotWaterHeaterTankFuel",
+         "modeler_description" : "[ModelMeasure] The measure will create a new instance of the OS:WaterHeater:Mixed object representing a fuel storage water heater. The water heater will be placed on the plant loop 'Domestic Hot Water Loop'. If this loop already exists, any water heater on that loop will be removed and replaced with a water heater consistent with this measure. If it doesn't exist, it will be created.",
+         "name" : "Set Residential Fuel Tank Water Heater"
+      },
+      {
+         "arguments" : {
+            "capacity" : 100000000,
+            "cycling_derate" : 0.080000000000000002,
+            "energy_factor" : 0.98999999999999999,
+            "location" : "auto",
+            "setpoint_temp" : 125
+         },
+         "description" : "This measure adds a new residential electric tankless water heater to the model based on user inputs. If there is already an existing residential water heater in the model, it is replaced. For multifamily buildings, the water heater can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHotWaterHeaterTanklessElectric",
+         "modeler_description" : "[ModelMeasure] The measure will create a new instance of the OS:WaterHeater:Mixed object representing a electric tankless water heater. The water heater will be placed on the plant loop 'Domestic Hot Water Loop'. If this loop already exists, any water heater on that loop will be removed and replaced with a water heater consistent with this measure. If it doesn't exist, it will be created.",
+         "name" : "Set Residential Electric Tankless Water Heater"
+      },
+      {
+         "arguments" : {
+            "capacity" : 100000000,
+            "cycling_derate" : 0.080000000000000002,
+            "energy_factor" : 0.81999999999999995,
+            "fuel_type" : "gas",
+            "location" : "auto",
+            "offcyc_power" : 5,
+            "oncyc_power" : 65,
+            "setpoint_temp" : 125
+         },
+         "description" : "This measure adds a new residential fuel tankless water heater to the model based on user inputs. If there is already an existing residential water heater in the model, it is replaced. For multifamily buildings, the water heater can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHotWaterHeaterTanklessFuel",
+         "modeler_description" : "[ModelMeasure] The measure will create a new instance of the OS:WaterHeater:Mixed object representing a fuel tankless water heater. The water heater will be placed on the plant loop 'Domestic Hot Water Loop'. If this loop already exists, any water heater on that loop will be removed and replaced with a water heater consistent with this measure. If it doesn't exist, it will be created.",
+         "name" : "Set Residential Fuel Tankless Water Heater"
+      },
+      {
+         "arguments" : {
+            "bath_mult" : 1,
+            "plant_loop" : "auto",
+            "shower_mult" : 1,
+            "sink_mult" : 1,
+            "space" : "auto"
+         },
+         "description" : "Adds (or replaces) residential hot water fixtures -- showers, sinks, and baths. For multifamily buildings, the hot water fixtures can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHotWaterFixtures",
+         "modeler_description" : "[ModelMeasure] Creates three new WaterUse:Equipment objects to represent showers, sinks, and baths in a home. OtherEquipment objects are also added to take into account the heat gain in the space due to hot water use.",
+         "name" : "Set Residential Hot Water Fixtures"
+      },
+      {
+         "arguments" : {
+            "dist_ins" : 0,
+            "dist_layout" : "trunk and branch",
+            "pipe_mat" : "copper",
+            "recirc_type" : "none",
+            "space" : "interior"
+         },
+         "description" : "Adds a hot water distribution system, including pipes and any recirculation pumps, into the home. This measure must be run after hot water fixtures have been added to the home. For multifamily buildings, the hot water fixtures can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHotWaterDistribution",
+         "modeler_description" : "[ModelMeasure] Modifies the existing HotWater:Equipment Objects for showers, sinks, and baths to take into account the additional water drawn due to distribution system inefficiencies. Also adds an internal gain to the space due to heat loss from the pipes and an ElectricEquipment object for the pump if recirculation is included.",
+         "name" : "Set Residential Hot Water Distribution"
+      },
+      {
+         "arguments" : {
+            "capacity" : "autosize",
+            "crankcase_capacity" : 0,
+            "crankcase_max_temp" : 55,
+            "eer" : 11.1,
+            "eer_capacity_derate_1ton" : 1,
+            "eer_capacity_derate_2ton" : 1,
+            "eer_capacity_derate_3ton" : 1,
+            "eer_capacity_derate_4ton" : 1,
+            "eer_capacity_derate_5ton" : 1,
+            "fan_power_installed" : 0.5,
+            "fan_power_rated" : 0.36499999999999999,
+            "seer" : 13,
+            "shr" : 0.72999999999999998
+         },
+         "description" : "This measure removes any existing HVAC cooling components from the building and adds a single-speed central air conditioner along with an on/off supply fan to a unitary air loop. For multifamily buildings, the single-speed central air conditioner can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACCentralAirConditionerSingleSpeed",
+         "modeler_description" : "[ModelMeasure] Any cooling components are removed from any existing air loops or zones. Any existing air loops are also removed. A cooling DX coil and an on/off supply fan are added to a unitary air loop. The unitary air loop is added to the supply inlet node of the air loop. This air loop is added to a branch for the living zone. A diffuser is added to the branch for the living zone as well as for the finished basement if it exists.",
+         "name" : "Set Residential Single-Speed Central Air Conditioner"
+      },
+      {
+         "arguments" : {
+            "cop" : 3.0499999999999998,
+            "cop_capacity_derate_1ton" : 1,
+            "cop_capacity_derate_2ton" : 1,
+            "cop_capacity_derate_3ton" : 1,
+            "cop_capacity_derate_4ton" : 1,
+            "cop_capacity_derate_5ton" : 1,
+            "crankcase_capacity" : 0.02,
+            "crankcase_max_temp" : 55,
+            "eer" : 11.4,
+            "eer_capacity_derate_1ton" : 1,
+            "eer_capacity_derate_2ton" : 1,
+            "eer_capacity_derate_3ton" : 1,
+            "eer_capacity_derate_4ton" : 1,
+            "eer_capacity_derate_5ton" : 1,
+            "fan_power_installed" : 0.5,
+            "fan_power_rated" : 0.36499999999999999,
+            "heat_pump_capacity" : "autosize",
+            "hspf" : 7.7000000000000002,
+            "min_temp" : 0,
+            "seer" : 13,
+            "shr" : 0.72999999999999998,
+            "supplemental_capacity" : "autosize"
+         },
+         "description" : "This measure removes any existing HVAC components from the building and adds a single-speed air source heat pump along with an on/off supply fan to a unitary air loop. For multifamily buildings, the single-speed air source heat pump can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACAirSourceHeatPumpSingleSpeed",
+         "modeler_description" : "[ModelMeasure] Any supply components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. Any existing air/plant loops are also removed. A heating DX coil, cooling DX coil, electric supplemental heating coil, and an on/off supply fan are added to a unitary air loop. The unitary air loop is added to the supply inlet node of the air loop. This air loop is added to a branch for the living zone. A diffuser is added to the branch for the living zone as well as for the finished basement if it exists.",
+         "name" : "Set Residential Single-Speed Air Source Heat Pump"
+      },
+      {
+         "arguments" : {
+            "capacity_ratio" : 0.71999999999999997,
+            "capacity_ratio2" : 1,
+            "cop" : 3.7999999999999998,
+            "cop2" : 3.2999999999999998,
+            "cop_capacity_derate_1ton" : 1,
+            "cop_capacity_derate_2ton" : 1,
+            "cop_capacity_derate_3ton" : 1,
+            "cop_capacity_derate_4ton" : 1,
+            "cop_capacity_derate_5ton" : 1,
+            "crankcase_capacity" : 0.02,
+            "crankcase_max_temp" : 55,
+            "eer" : 13.1,
+            "eer2" : 11.699999999999999,
+            "eer_capacity_derate_1ton" : 1,
+            "eer_capacity_derate_2ton" : 1,
+            "eer_capacity_derate_3ton" : 1,
+            "eer_capacity_derate_4ton" : 1,
+            "eer_capacity_derate_5ton" : 1,
+            "fan_power_installed" : 0.29999999999999999,
+            "fan_power_rated" : 0.14000000000000001,
+            "fan_speed_ratio_cooling" : 0.85999999999999999,
+            "fan_speed_ratio_cooling2" : 1,
+            "fan_speed_ratio_heating" : 0.80000000000000004,
+            "fan_speed_ratio_heating2" : 1,
+            "heat_pump_capacity" : "autosize",
+            "hspf" : 8.5999999999999996,
+            "min_temp" : 0,
+            "seer" : 16,
+            "shr" : 0.70999999999999996,
+            "shr2" : 0.72299999999999998,
+            "supplemental_capacity" : "autosize"
+         },
+         "description" : "This measure removes any existing HVAC components from the building and adds a two-speed air source heat pump along with an on/off supply fan to a unitary air loop. For multifamily buildings, the two-speed air source heat pump can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACAirSourceHeatPumpTwoSpeed",
+         "modeler_description" : "[ModelMeasure] Any supply components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. Any existing air/plant loops are also removed. A heating DX coil, cooling DX coil, electric supplemental heating coil, and an on/off supply fan are added to a unitary air loop. The unitary air loop is added to the supply inlet node of the air loop. This air loop is added to a branch for the living zone. A diffuser is added to the branch for the living zone as well as for the finished basement if it exists.",
+         "name" : "Set Residential Two-Speed Air Source Heat Pump"
+      },
+      {
+         "arguments" : {
+            "capacity_ratio" : 0.48999999999999999,
+            "capacity_ratio2" : 0.67000000000000004,
+            "capacity_ratio3" : 1,
+            "capacity_ratio4" : 1.2,
+            "cop" : 4.8200000000000003,
+            "cop2" : 4.5599999999999996,
+            "cop3" : 3.8900000000000001,
+            "cop4" : 3.9199999999999999,
+            "cop_capacity_derate_1ton" : 1,
+            "cop_capacity_derate_2ton" : 1,
+            "cop_capacity_derate_3ton" : 1,
+            "cop_capacity_derate_4ton" : 1,
+            "cop_capacity_derate_5ton" : 1,
+            "crankcase_capacity" : 0.02,
+            "crankcase_max_temp" : 55,
+            "eer" : 17.399999999999999,
+            "eer2" : 16.800000000000001,
+            "eer3" : 14.300000000000001,
+            "eer4" : 13,
+            "eer_capacity_derate_1ton" : 1,
+            "eer_capacity_derate_2ton" : 1,
+            "eer_capacity_derate_3ton" : 0.94999999999999996,
+            "eer_capacity_derate_4ton" : 0.94999999999999996,
+            "eer_capacity_derate_5ton" : 0.94999999999999996,
+            "fan_power_installed" : 0.29999999999999999,
+            "fan_power_rated" : 0.14000000000000001,
+            "fan_speed_ratio_cooling" : 0.69999999999999996,
+            "fan_speed_ratio_cooling2" : 0.90000000000000002,
+            "fan_speed_ratio_cooling3" : 1,
+            "fan_speed_ratio_cooling4" : 1.26,
+            "fan_speed_ratio_heating" : 0.73999999999999999,
+            "fan_speed_ratio_heating2" : 0.92000000000000004,
+            "fan_speed_ratio_heating3" : 1,
+            "fan_speed_ratio_heating4" : 1.22,
+            "heat_pump_capacity" : "autosize",
+            "hspf" : 10,
+            "min_temp" : 0,
+            "seer" : 22,
+            "shr" : 0.83999999999999997,
+            "shr2" : 0.79000000000000004,
+            "shr3" : 0.76000000000000001,
+            "shr4" : 0.77000000000000002,
+            "supplemental_capacity" : "autosize"
+         },
+         "description" : "This measure removes any existing HVAC components from the building and adds a variable-speed air source heat pump along with an on/off supply fan to a unitary air loop. For multifamily buildings, the variable-speed air source heat pump can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACAirSourceHeatPumpVariableSpeed",
+         "modeler_description" : "[ModelMeasure] Any supply components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. Any existing air/plant loops are also removed. A heating DX coil, cooling DX coil, electric supplemental heating coil, and an on/off supply fan are added to a unitary air loop. The unitary air loop is added to the supply inlet node of the air loop. This air loop is added to a branch for the living zone. A diffuser is added to the branch for the living zone as well as for the finished basement if it exists.",
+         "name" : "Set Residential Variable-Speed Air Source Heat Pump"
+      },
+      {
+         "arguments" : {
+            "afue" : 1,
+            "capacity" : "autosize",
+            "design_temp" : 180,
+            "oat_high" : "Optional - High Outside Air Temperature.",
+            "oat_hwst_high" : "Optional - Hot Water Supply Temperature corresponding to High Outside Air Temperature.",
+            "oat_hwst_low" : "Optional - Hot Water Supply Temperature corresponding to Low Outside Air Temperature.",
+            "oat_low" : "Optional - Low Outside Air Temperature.",
+            "oat_reset_enabled" : false,
+            "system_type" : "hot water, forced draft"
+         },
+         "description" : "This measure removes any existing HVAC heating components from the building and adds a boiler along with constant speed pump and water baseboard coils to a hot water plant loop. For multifamily buildings, the supply components on the plant loop can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACBoilerElectric",
+         "modeler_description" : "[ModelMeasure] Any heating components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. A boiler along with constant speed pump and water baseboard coils are added to a hot water plant loop.",
+         "name" : "Set Residential Boiler Electric"
+      },
+      {
+         "arguments" : {
+            "afue" : 0.80000000000000004,
+            "capacity" : "autosize",
+            "design_temp" : 180,
+            "fuel_type" : "gas",
+            "oat_high" : "Optional - High Outside Air Temperature.",
+            "oat_hwst_high" : "Optional - Hot Water Supply Temperature corresponding to High Outside Air Temperature.",
+            "oat_hwst_low" : "Optional - Hot Water Supply Temperature corresponding to Low Outside Air Temperature.",
+            "oat_low" : "Optional - Low Outside Air Temperature.",
+            "oat_reset_enabled" : false,
+            "system_type" : "hot water, forced draft"
+         },
+         "description" : "This measure removes any existing HVAC heating components from the building and adds a boiler along with constant speed pump and water baseboard coils to a hot water plant loop. For multifamily buildings, the supply components on the plant loop can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACBoilerFuel",
+         "modeler_description" : "[ModelMeasure] Any heating components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. A boiler along with constant speed pump and water baseboard coils are added to a hot water plant loop.",
+         "name" : "Set Residential Boiler Fuel"
+      },
+      {
+         "arguments" : {
+            "capacity" : "autosize",
+            "capacity_ratio" : 0.71999999999999997,
+            "capacity_ratio2" : 1,
+            "crankcase_capacity" : 0,
+            "crankcase_max_temp" : 55,
+            "eer" : 13.5,
+            "eer2" : 12.4,
+            "eer_capacity_derate_1ton" : 1,
+            "eer_capacity_derate_2ton" : 1,
+            "eer_capacity_derate_3ton" : 1,
+            "eer_capacity_derate_4ton" : 1,
+            "eer_capacity_derate_5ton" : 1,
+            "fan_power_installed" : 0.29999999999999999,
+            "fan_power_rated" : 0.14000000000000001,
+            "fan_speed_ratio" : 0.85999999999999999,
+            "fan_speed_ratio2" : 1,
+            "seer" : 16,
+            "shr" : 0.70999999999999996,
+            "shr2" : 0.72999999999999998
+         },
+         "description" : "This measure removes any existing HVAC cooling components from the building and adds a two-speed central air conditioner along with an on/off supply fan to a unitary air loop. For multifamily buildings, the two-speed central air conditioner can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACCentralAirConditionerTwoSpeed",
+         "modeler_description" : "[ModelMeasure] Any cooling components are removed from any existing air loops or zones. Any existing air loops are also removed. A cooling DX coil and an on/off supply fan are added to a unitary air loop. The unitary air loop is added to the supply inlet node of the air loop. This air loop is added to a branch for the living zone. A diffuser is added to the branch for the living zone as well as for the finished basement if it exists.",
+         "name" : "Set Residential Two-Speed Central Air Conditioner"
+      },
+      {
+         "arguments" : {
+            "capacity" : "autosize",
+            "capacity_ratio" : 0.35999999999999999,
+            "capacity_ratio2" : 0.64000000000000001,
+            "capacity_ratio3" : 1,
+            "capacity_ratio4" : 1.1599999999999999,
+            "crankcase_capacity" : 0,
+            "crankcase_max_temp" : 55,
+            "eer" : 19.199999999999999,
+            "eer2" : 18.300000000000001,
+            "eer3" : 16.5,
+            "eer4" : 14.6,
+            "eer_capacity_derate_1ton" : 1,
+            "eer_capacity_derate_2ton" : 1,
+            "eer_capacity_derate_3ton" : 0.89000000000000001,
+            "eer_capacity_derate_4ton" : 0.89000000000000001,
+            "eer_capacity_derate_5ton" : 0.89000000000000001,
+            "fan_power_installed" : 0.29999999999999999,
+            "fan_power_rated" : 0.14000000000000001,
+            "fan_speed_ratio" : 0.51000000000000001,
+            "fan_speed_ratio2" : 0.83999999999999997,
+            "fan_speed_ratio3" : 1,
+            "fan_speed_ratio4" : 1.1899999999999999,
+            "seer" : 24.5,
+            "shr" : 0.97999999999999998,
+            "shr2" : 0.81999999999999995,
+            "shr3" : 0.745,
+            "shr4" : 0.77000000000000002
+         },
+         "description" : "This measure removes any existing HVAC cooling components from the building and adds a variable-speed central air conditioner along with an on/off supply fan to a unitary air loop. For multifamily buildings, the variable-speed central air conditioner can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACCentralAirConditionerVariableSpeed",
+         "modeler_description" : "[ModelMeasure] Any cooling components are removed from any existing air loops or zones. Any existing air loops are also removed. A cooling DX coil and an on/off supply fan are added to a unitary air loop. The unitary air loop is added to the supply inlet node of the air loop. This air loop is added to a branch for the living zone. A diffuser is added to the branch for the living zone as well as for the finished basement if it exists.",
+         "name" : "Set Residential Variable-Speed Central Air Conditioner"
+      },
+      {
+         "arguments" : {
+            "air_flow_rate" : "auto",
+            "energy_factor" : "auto",
+            "humidity_setpoint" : 0.59999999999999998,
+            "water_removal_rate" : "auto"
+         },
+         "description" : "This measure removes any existing dehumidifiers from the building and adds a dehumidifier. For multifamily buildings, the dehumidifier can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACDehumidifier",
+         "modeler_description" : "[ModelMeasure] Any HVAC dehumidifier DXs are removed from any existing zones. An HVAC dehumidifier DX is added to the living zone, as well as to the finished basement if it exists. A humidistat is also added to the zone, with the relative humidity setpoint input by the user.",
+         "name" : "Set Residential Dehumidifier"
+      },
+      {
+         "arguments" : {
+            "capacity" : "autosize",
+            "efficiency" : 1
+         },
+         "description" : "This measure removes any existing electric baseboards from the building and adds electric baseboards. For multifamily buildings, the electric baseboard can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACElectricBaseboard",
+         "modeler_description" : "[ModelMeasure] Any heating components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. An HVAC baseboard convective electric is added to the living zone, as well as to the finished basement if it exists.",
+         "name" : "Set Residential Electric Baseboard"
+      },
+      {
+         "arguments" : {
+            "afue" : 1,
+            "capacity" : "autosize",
+            "fan_power_installed" : 0.5
+         },
+         "description" : "This measure removes any existing HVAC heating components from the building and adds a furnace along with an on/off supply fan to a unitary air loop. For multifamily buildings, the furnace can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACFurnaceElectric",
+         "modeler_description" : "[ModelMeasure] Any heating components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. Any existing air/plant loops are also removed. An electric heating coil and an on/off supply fan are added to a unitary air loop. The unitary air loop is added to the supply inlet node of the air loop. This air loop is added to a branch for the living zone. A diffuser is added to the branch for the living zone as well as for the finished basement if it exists.",
+         "name" : "Set Residential Furnace Electric"
+      },
+      {
+         "arguments" : {
+            "afue" : 0.78000000000000003,
+            "capacity" : "autosize",
+            "fan_power_installed" : 0.5,
+            "fuel_type" : "gas"
+         },
+         "description" : "This measure removes any existing HVAC heating components from the building and adds a furnace along with an on/off supply fan to a unitary air loop. For multifamily buildings, the furnace can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACFurnaceFuel",
+         "modeler_description" : "[ModelMeasure] Any heating components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. Any existing air/plant loops are also removed. A fuel heating coil and an on/off supply fan are added to a unitary air loop. The unitary air loop is added to the supply inlet node of the air loop. This air loop is added to a branch for the living zone. A diffuser is added to the branch for the living zone as well as for the finished basement if it exists.",
+         "name" : "Set Residential Furnace Fuel"
+      },
+      {
+         "arguments" : {
+            "bore_config" : "autosize",
+            "bore_depth" : "autosize",
+            "bore_diameter" : 5,
+            "bore_holes" : "autosize",
+            "bore_spacing" : 20,
+            "cop" : 3.6000000000000001,
+            "design_delta_t" : 10,
+            "eer" : 16.600000000000001,
+            "fan_power" : 0.5,
+            "fluid_type" : "propylene-glycol",
+            "frac_glycol" : 0.29999999999999999,
+            "ground_conductivity" : 0.59999999999999998,
+            "ground_diffusivity" : 0.020799999999999999,
+            "grout_conductivity" : 0.40000000000000002,
+            "gshp_capacity" : "3.0",
+            "pipe_size" : 0.75,
+            "pump_head" : 50,
+            "rated_shr" : 0.73199999999999998,
+            "supplemental_capacity" : "autosize",
+            "u_tube_leg_spacing" : 0.96609999999999996
+         },
+         "description" : "This measure removes any existing HVAC components from the building and adds a ground heat exchanger along with variable speed pump and water to air heat pump coils to a condenser plant loop. For multifamily buildings, the supply components on the plant loop can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACGroundSourceHeatPumpVerticalBore",
+         "modeler_description" : "[ModelMeasure] Any supply components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. A ground heat exchanger along with variable speed pump and water to air heat pump coils are added to a condenser plant loop.",
+         "name" : "Set Residential Ground Source Heat Pump Vertical Bore"
+      },
+      {
+         "arguments" : {
+            "cap_retention_frac" : 0.25,
+            "cap_retention_temp" : -5,
+            "fan_power" : 0.070000000000000007,
+            "heat_pump_capacity" : "autosize",
+            "heating_capacity_offset" : 2300,
+            "hspf" : 8.1999999999999993,
+            "max_cooling_airflow_rate" : 425,
+            "max_cooling_capacity" : 1.2,
+            "max_heating_airflow_rate" : 400,
+            "max_heating_capacity" : 1.2,
+            "min_cooling_airflow_rate" : 200,
+            "min_cooling_capacity" : 0.40000000000000002,
+            "min_heating_airflow_rate" : 200,
+            "min_heating_capacity" : 0.29999999999999999,
+            "pan_heater_power" : 0,
+            "seer" : 14.5,
+            "shr" : 0.72999999999999998,
+            "supplemental_capacity" : "autosize",
+            "supplemental_efficiency" : 1
+         },
+         "description" : "This measure removes any existing HVAC components from the building and adds a mini-split heat pump. For multifamily buildings, the mini-split heat pump can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACMiniSplitHeatPump",
+         "modeler_description" : "[ModelMeasure] Any supply components or baseboard convective electrics/waters are removed from any existing air/plant loops or zones. Any existing air/plant loops are also removed. A heating DX coil, cooling DX coil, and an on/off supply fan are added to a variable refrigerant flow terminal unit.",
+         "name" : "Set Residential Mini-Split Heat Pump"
+      },
+      {
+         "arguments" : {
+            "airflow_rate" : 350,
+            "capacity" : "autosize",
+            "eer" : 8.5,
+            "shr" : 0.65000000000000002
+         },
+         "description" : "This measure removes any existing HVAC cooling components from the building and adds a room air conditioner. For multifamily buildings, the room air conditioner can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACRoomAirConditioner",
+         "modeler_description" : "[ModelMeasure] Any cooling components are removed from any existing air loops or zones. Any existing air loops are also removed. An HVAC packaged terminal air conditioner is added to the living zone.",
+         "name" : "Set Residential Room Air Conditioner"
+      },
+      {
+         "arguments" : {
+            "htg_wkdy" : "71",
+            "htg_wked" : "71"
+         },
+         "description" : "This measure creates the heating season schedules based on weather data, and the heating setpoint schedules.",
+         "measure_dir_name" : "ResidentialHVACHeatingSetpoints",
+         "modeler_description" : "[ModelMeasure] This measure creates residential heating season ruleset objects. Schedule values are populated based on information contained in the EPW file. This measure also creates residential heating setpoint ruleset objects. Schedule values are populated based on information input by the user as well as contained in the residential heating season. The heating setpoint schedules are added to the living zone's thermostat.",
+         "name" : "Set Residential Heating Setpoints and Schedules"
+      },
+      {
+         "arguments" : {
+            "clg_wkdy" : "76",
+            "clg_wked" : "76"
+         },
+         "description" : "This measure creates the cooling season schedules based on weather data, and the cooling setpoint schedules.",
+         "measure_dir_name" : "ResidentialHVACCoolingSetpoints",
+         "modeler_description" : "[ModelMeasure] This measure creates residential cooling season ruleset objects. Schedule values are populated based on information contained in the EPW file. This measure also creates residential cooling setpoint ruleset objects. Schedule values are populated based on information input by the user as well as contained in the residential cooling season. The cooling setpoint schedules are added to the living zone's thermostat.",
+         "name" : "Set Residential Cooling Setpoints and Schedules"
+      },
+      {
+         "arguments" : {
+            "control" : "typical",
+            "cooling_setpoint_offset" : 0,
+            "coverage" : "NA",
+            "monthly_sch" : "1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248",
+            "mult" : 1,
+            "power" : 45,
+            "specified_num" : "1",
+            "use_benchmark_energy" : true,
+            "weekday_sch" : "0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05",
+            "weekend_sch" : "0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05"
+         },
+         "description" : "Adds (or replaces) residential ceiling fan(s) and schedule in all finished spaces. For multifamily buildings, the ceiling fan(s) can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialHVACCeilingFan",
+         "modeler_description" : "[ModelMeasure] Since there is no Ceiling Fan object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is residential ceiling fan. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Ceiling Fan"
+      },
+      {
+         "arguments" : {
+            "fridge_E" : 434,
+            "monthly_sch" : "0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837",
+            "mult" : 1,
+            "space" : "auto",
+            "weekday_sch" : "0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041",
+            "weekend_sch" : "0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041"
+         },
+         "description" : "Adds (or replaces) a residential refrigerator with the specified efficiency, operation, and schedule. For multifamily buildings, the refrigerator can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialApplianceRefrigerator",
+         "modeler_description" : "[ModelMeasure] Since there is no Refrigerator object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is a residential refrigerator. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model.",
+         "name" : "Set Residential Refrigerator"
+      },
+      {
+         "arguments" : {
+            "cw_annual_cost" : 24,
+            "cw_cold_cycle" : false,
+            "cw_drum_volume" : 3.5,
+            "cw_fill_sensor" : false,
+            "cw_imef" : 0.94999999999999996,
+            "cw_internal_heater" : false,
+            "cw_mult_e" : 1,
+            "cw_mult_hw" : 1,
+            "cw_rated_annual_energy" : 387,
+            "cw_test_date" : 2007,
+            "cw_thermostatic_control" : true,
+            "plant_loop" : "auto",
+            "space" : "auto"
+         },
+         "description" : "Adds (or replaces) a residential clothes washer with the specified efficiency, operation, and schedule. For multifamily buildings, the clothes washer can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialApplianceClothesWasher",
+         "modeler_description" : "[ModelMeasure] Since there is no Clothes Washer object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is a residential clothes washer. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Clothes Washer"
+      },
+      {
+         "arguments" : {
+            "cd_cef" : 2.7000000000000002,
+            "cd_monthly_sch" : "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0",
+            "cd_mult" : 1,
+            "cd_weekday_sch" : "0.010, 0.006, 0.004, 0.002, 0.004, 0.006, 0.016, 0.032, 0.048, 0.068, 0.078, 0.081, 0.074, 0.067, 0.057, 0.061, 0.055, 0.054, 0.051, 0.051, 0.052, 0.054, 0.044, 0.024",
+            "cd_weekend_sch" : "0.010, 0.006, 0.004, 0.002, 0.004, 0.006, 0.016, 0.032, 0.048, 0.068, 0.078, 0.081, 0.074, 0.067, 0.057, 0.061, 0.055, 0.054, 0.051, 0.051, 0.052, 0.054, 0.044, 0.024",
+            "cw_drum_volume" : 3.5,
+            "cw_imef" : 0.94999999999999996,
+            "cw_rated_annual_energy" : 387,
+            "space" : "auto"
+         },
+         "description" : "Adds (or replaces) a residential clothes dryer with the specified efficiency, operation, and schedule. For multifamily buildings, the clothes dryer can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialApplianceClothesDryerElectric",
+         "modeler_description" : "[ModelMeasure] Since there is no Clothes Dryer object in OpenStudio/EnergyPlus, we look for an ElectricEquipment or OtherEquipment object with the name that denotes it is a residential clothes dryer. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Electric Clothes Dryer"
+      },
+      {
+         "arguments" : {
+            "cd_cef" : 2.3999999999999999,
+            "cd_fuel_split" : 0.070000000000000007,
+            "cd_fuel_type" : "gas",
+            "cd_monthly_sch" : "1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0",
+            "cd_mult" : 1,
+            "cd_weekday_sch" : "0.010, 0.006, 0.004, 0.002, 0.004, 0.006, 0.016, 0.032, 0.048, 0.068, 0.078, 0.081, 0.074, 0.067, 0.057, 0.061, 0.055, 0.054, 0.051, 0.051, 0.052, 0.054, 0.044, 0.024",
+            "cd_weekend_sch" : "0.010, 0.006, 0.004, 0.002, 0.004, 0.006, 0.016, 0.032, 0.048, 0.068, 0.078, 0.081, 0.074, 0.067, 0.057, 0.061, 0.055, 0.054, 0.051, 0.051, 0.052, 0.054, 0.044, 0.024",
+            "cw_drum_volume" : 3.5,
+            "cw_imef" : 0.94999999999999996,
+            "cw_rated_annual_energy" : 387,
+            "space" : "auto"
+         },
+         "description" : "Adds (or replaces) a residential clothes dryer with the specified efficiency, operation, and schedule. For multifamily buildings, the clothes dryer can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialApplianceClothesDryerFuel",
+         "modeler_description" : "[ModelMeasure] Since there is no Clothes Dryer object in OpenStudio/EnergyPlus, we look for an OtherEquipment or GasEquipment object with the name that denotes it is a residential clothes dryer. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Fuel Clothes Dryer"
+      },
+      {
+         "arguments" : {
+            "cold_inlet" : false,
+            "cold_use" : 0,
+            "dw_E" : 290,
+            "eg_date" : 2007,
+            "eg_gas_cost" : 23,
+            "int_htr" : true,
+            "mult_e" : 1,
+            "mult_hw" : 1,
+            "num_settings" : 12,
+            "plant_loop" : "auto",
+            "space" : "auto"
+         },
+         "description" : "Adds (or replaces) a residential dishwasher with the specified efficiency, operation, and schedule. For multifamily buildings, the dishwasher can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialApplianceDishwasher",
+         "modeler_description" : "[ModelMeasure] Since there is no Dishwasher object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is a residential dishwasher. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Dishwasher"
+      },
+      {
+         "arguments" : {
+            "c_ef" : 0.73999999999999999,
+            "monthly_sch" : "1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097",
+            "mult" : 1,
+            "o_ef" : 0.11,
+            "space" : "auto",
+            "weekday_sch" : "0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011",
+            "weekend_sch" : "0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011"
+         },
+         "description" : "Adds (or replaces) a residential cooking range with the specified efficiency, operation, and schedule. For multifamily buildings, the cooking range can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialApplianceCookingRangeElectric",
+         "modeler_description" : "[ModelMeasure] Since there is no Cooking Range object in OpenStudio/EnergyPlus, we look for an ElectricEquipment or OtherEquipment object with the name that denotes it is a residential cooking range. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Electric Cooking Range"
+      },
+      {
+         "arguments" : {
+            "c_ef" : 0.40000000000000002,
+            "e_ignition" : true,
+            "fuel_type" : "gas",
+            "monthly_sch" : "1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097",
+            "mult" : 1,
+            "o_ef" : 0.058000000000000003,
+            "space" : "auto",
+            "weekday_sch" : "0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011",
+            "weekend_sch" : "0.007, 0.007, 0.004, 0.004, 0.007, 0.011, 0.025, 0.042, 0.046, 0.048, 0.042, 0.050, 0.057, 0.046, 0.057, 0.044, 0.092, 0.150, 0.117, 0.060, 0.035, 0.025, 0.016, 0.011"
+         },
+         "description" : "Adds (or replaces) a residential cooking range with the specified efficiency, operation, and schedule. For multifamily buildings, the cooking range can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialApplianceCookingRangeFuel",
+         "modeler_description" : "[ModelMeasure] Since there is no Cooking Range object in OpenStudio/EnergyPlus, we look for an OtherEquipment or ElectricEquipment object with the name that denotes it is a residential cooking range. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Fuel Cooking Range"
+      },
+      {
+         "arguments" : {
+            "cfl_eff" : 55,
+            "hw_cfl" : 0.34000000000000002,
+            "hw_led" : 0,
+            "hw_lfl" : 0,
+            "in_eff" : 15,
+            "led_eff" : 80,
+            "lfl_eff" : 88,
+            "pg_cfl" : 0.34000000000000002,
+            "pg_led" : 0,
+            "pg_lfl" : 0
+         },
+         "description" : "Sets (or replaces) the lighting energy use, based on fractions of CFLs, LFLs, and LEDs, for finished spaces, the garage, and outside. For multifamily buildings, the lighting can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialLighting",
+         "modeler_description" : "[ModelMeasure] Assigns a lighting energy use and schedule to finished spaces, the garage, and outside. The lighting schedule is calculated for the latitude/longitude of the weather location specified in the model.",
+         "name" : "Set Residential Lighting"
+      },
+      {
+         "arguments" : {
+            "monthly_sch" : "1.248, 1.257, 0.993, 0.989, 0.993, 0.827, 0.821, 0.821, 0.827, 0.99, 0.987, 1.248",
+            "mult" : 1,
+            "weekday_sch" : "0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05",
+            "weekend_sch" : "0.04, 0.037, 0.037, 0.036, 0.033, 0.036, 0.043, 0.047, 0.034, 0.023, 0.024, 0.025, 0.024, 0.028, 0.031, 0.032, 0.039, 0.053, 0.063, 0.067, 0.071, 0.069, 0.059, 0.05"
+         },
+         "description" : "Adds (or replaces) residential plug loads with the specified efficiency and schedule in all finished spaces. For multifamily buildings, the plug loads can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscPlugLoads",
+         "modeler_description" : "[ModelMeasure] Since there is no Plug Loads object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is residential plug loads. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Plug Loads"
+      },
+      {
+         "arguments" : {
+            "fridge_E" : 1102,
+            "monthly_sch" : "0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837",
+            "mult" : 1,
+            "space" : "auto",
+            "weekday_sch" : "0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041",
+            "weekend_sch" : "0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041"
+         },
+         "description" : "Adds (or replaces) a residential extra refrigerator with the specified efficiency, operation, and schedule. For multifamily buildings, the extra refrigerator can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscExtraRefrigerator",
+         "modeler_description" : "[ModelMeasure] Since there is no Extra Refrigerator object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is a residential extra refrigerator. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model.",
+         "name" : "Set Residential Extra Refrigerator"
+      },
+      {
+         "arguments" : {
+            "freezer_E" : 935,
+            "monthly_sch" : "0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837",
+            "mult" : 1,
+            "space" : "auto",
+            "weekday_sch" : "0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041",
+            "weekend_sch" : "0.040, 0.039, 0.038, 0.037, 0.036, 0.036, 0.038, 0.040, 0.041, 0.041, 0.040, 0.040, 0.042, 0.042, 0.042, 0.041, 0.044, 0.048, 0.050, 0.048, 0.047, 0.046, 0.044, 0.041"
+         },
+         "description" : "Adds (or replaces) a residential freezer with the specified efficiency, operation, and schedule. For multifamily buildings, the freezer can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscFreezer",
+         "modeler_description" : "[ModelMeasure] Since there is no Freezer object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is a residential freezer. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model.",
+         "name" : "Set Residential Freezer"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 1027.3,
+            "monthly_sch" : "0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024",
+            "weekend_sch" : "0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024"
+         },
+         "description" : "Adds (or replaces) a residential hot tub heater with the specified efficiency and schedule. The hot tub is assumed to be outdoors. For multifamily buildings, the hot tub heater is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscHotTubHeaterElectric",
+         "modeler_description" : "[ModelMeasure] Since there is no Hot Tub Heater object in OpenStudio/EnergyPlus, we look for an ElectricEquipment or GasEquipment object with the name that denotes it is a residential hot tub heater. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Hot Tub Electric Heater"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 81,
+            "monthly_sch" : "0.837, 0.835, 1.084, 1.084, 1.084, 1.096, 1.096, 1.096, 1.096, 0.931, 0.925, 0.837",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024",
+            "weekend_sch" : "0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024"
+         },
+         "description" : "Adds (or replaces) a residential hot tub heater with the specified efficiency and schedule. The hot tub is assumed to be outdoors. For multifamily buildings, the hot tub heater is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscHotTubHeaterGas",
+         "modeler_description" : "[ModelMeasure] Since there is no Hot Tub Heater object in OpenStudio/EnergyPlus, we look for a GasEquipment or ElectricEquipment object with the name that denotes it is a residential hot tub heater. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Hot Tub Gas Heater"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 1014.1,
+            "monthly_sch" : "0.921, 0.928, 0.921, 0.915, 0.921, 1.160, 1.158, 1.158, 1.160, 0.921, 0.915, 0.921",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024",
+            "weekend_sch" : "0.024, 0.029, 0.024, 0.029, 0.047, 0.067, 0.057, 0.024, 0.024, 0.019, 0.015, 0.014, 0.014, 0.014, 0.024, 0.058, 0.126, 0.122, 0.068, 0.061, 0.051, 0.043, 0.024, 0.024"
+         },
+         "description" : "Adds (or replaces) a residential hot tub pump with the specified efficiency and schedule. The hot tub is assumed to be outdoors. For multifamily buildings, the hot tub pump is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscHotTubPump",
+         "modeler_description" : "[ModelMeasure] Since there is no Hot Tub Pump object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is a residential hot tub pump. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Hot Tub Pump"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 2300,
+            "monthly_sch" : "1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003",
+            "weekend_sch" : "0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003"
+         },
+         "description" : "Adds (or replaces) a residential pool heater with the specified efficiency and schedule. The pool is assumed to be outdoors. For multifamily buildings, the pool heater is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscPoolHeaterElectric",
+         "modeler_description" : "[ModelMeasure] Since there is no Pool Heater object in OpenStudio/EnergyPlus, we look for an ElectricEquipment or GasEquipment object with the name that denotes it is a residential pool heater. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Pool Electric Heater"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 222,
+            "monthly_sch" : "1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003",
+            "weekend_sch" : "0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003"
+         },
+         "description" : "Adds (or replaces) a residential pool heater with the specified efficiency and schedule. The pool is assumed to be outdoors. For multifamily buildings, the pool heater is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscPoolHeaterGas",
+         "modeler_description" : "[ModelMeasure] Since there is no Pool Heater object in OpenStudio/EnergyPlus, we look for a GasEquipment or ElectricEquipment object with the name that denotes it is a residential pool heater. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Pool Gas Heater"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 2250,
+            "monthly_sch" : "1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003",
+            "weekend_sch" : "0.003, 0.003, 0.003, 0.004, 0.008, 0.015, 0.026, 0.044, 0.084, 0.121, 0.127, 0.121, 0.120, 0.090, 0.075, 0.061, 0.037, 0.023, 0.013, 0.008, 0.004, 0.003, 0.003, 0.003"
+         },
+         "description" : "Adds (or replaces) a residential pool pump with the specified efficiency and schedule. The pool is assumed to be outdoors. For multifamily buildings, the pool pump is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscPoolPump",
+         "modeler_description" : "[ModelMeasure] Since there is no Pool Pump object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is a residential pool pump. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Pool Pump"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 400,
+            "monthly_sch" : "1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065",
+            "weekend_sch" : "0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065"
+         },
+         "description" : "Adds (or replaces) a residential well pump with the specified efficiency and schedule. The well is assumed to be outdoors. For multifamily buildings, the well pump is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscWellPump",
+         "modeler_description" : "[ModelMeasure] Since there is no Well Pump object in OpenStudio/EnergyPlus, we look for an ElectricEquipment object with the name that denotes it is a residential well pump. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Well Pump"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 60,
+            "monthly_sch" : "1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154",
+            "mult" : 1,
+            "scale_energy" : true,
+            "space" : "auto",
+            "weekday_sch" : "0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065",
+            "weekend_sch" : "0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065"
+         },
+         "description" : "Adds (or replaces) a residential gas fireplace with the specified efficiency and schedule. For multifamily buildings, the fireplace can be set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscGasFireplace",
+         "modeler_description" : "[ModelMeasure] Since there is no Gas Fireplace object in OpenStudio/EnergyPlus, we look for a GasEquipment object with the name that denotes it is a residential gas fireplace. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Gas Fireplace"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 30,
+            "monthly_sch" : "1.097, 1.097, 0.991, 0.987, 0.991, 0.890, 0.896, 0.896, 0.890, 1.085, 1.085, 1.097",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007",
+            "weekend_sch" : "0.004, 0.001, 0.001, 0.002, 0.007, 0.012, 0.029, 0.046, 0.044, 0.041, 0.044, 0.046, 0.042, 0.038, 0.049, 0.059, 0.110, 0.161, 0.115, 0.070, 0.044, 0.019, 0.013, 0.007"
+         },
+         "description" : "Adds (or replaces) a residential gas grill with the specified efficiency and schedule. The grill is assumed to be outdoors. For multifamily buildings, the grill is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscGasGrill",
+         "modeler_description" : "[ModelMeasure] Since there is no Gas Grill object in OpenStudio/EnergyPlus, we look for a GasEquipment object with the name that denotes it is a residential gas grill. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Gas Grill"
+      },
+      {
+         "arguments" : {
+            "base_energy" : 19,
+            "monthly_sch" : "1.154, 1.161, 1.013, 1.010, 1.013, 0.888, 0.883, 0.883, 0.888, 0.978, 0.974, 1.154",
+            "mult" : 1,
+            "scale_energy" : true,
+            "weekday_sch" : "0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065",
+            "weekend_sch" : "0.044, 0.023, 0.019, 0.015, 0.016, 0.018, 0.026, 0.033, 0.033, 0.032, 0.033, 0.033, 0.032, 0.032, 0.032, 0.033, 0.045, 0.057, 0.066, 0.076, 0.081, 0.086, 0.075, 0.065"
+         },
+         "description" : "Adds (or replaces) residential gas lighting with the specified efficiency and schedule. The lighting is assumed to be outdoors. For multifamily buildings, the lighting is set for all units of the building.",
+         "measure_dir_name" : "ResidentialMiscGasLighting",
+         "modeler_description" : "[ModelMeasure] Since there is no Gas Lighting object in OpenStudio/EnergyPlus, we look for a GasEquipment object with the name that denotes it is residential gas lighting. If one is found, it is replaced with the specified properties. Otherwise, a new such object is added to the model. Note: This measure requires the number of bedrooms/bathrooms to have already been assigned.",
+         "name" : "Set Residential Gas Lighting"
+      },
+      {
+         "arguments" : {
+            "clothes_dryer_exhaust" : 100,
+            "crawl_ach" : 0,
+            "duct_ah_return_frac" : 0.26700000000000002,
+            "duct_ah_supply_frac" : 0.067000000000000004,
+            "duct_location" : "auto",
+            "duct_location_frac" : "auto",
+            "duct_num_returns" : "auto",
+            "duct_return_area_mult" : 1,
+            "duct_return_frac" : 0.067000000000000004,
+            "duct_supply_area_mult" : 1,
+            "duct_supply_frac" : 0.59999999999999998,
+            "duct_total_leakage" : 0.29999999999999999,
+            "duct_unconditioned_r" : 0,
+            "finished_basement_ach" : 0,
+            "garage_ach50" : 7,
+            "has_fireplace_chimney" : false,
+            "has_hvac_flue" : false,
+            "has_water_heater_flue" : false,
+            "is_existing_home" : false,
+            "living_ach50" : 7,
+            "mech_vent_ashrae_std" : "2010",
+            "mech_vent_fan_power" : 0.29999999999999999,
+            "mech_vent_frac_62_2" : 1,
+            "mech_vent_infil_credit" : true,
+            "mech_vent_sensible_efficiency" : 0,
+            "mech_vent_total_efficiency" : 0,
+            "mech_vent_type" : "exhaust",
+            "nat_vent_clg_offset" : 1,
+            "nat_vent_clg_season" : true,
+            "nat_vent_frac_window_area_openable" : 0.20000000000000001,
+            "nat_vent_frac_windows_open" : 0.33000000000000002,
+            "nat_vent_htg_offset" : 1,
+            "nat_vent_htg_season" : true,
+            "nat_vent_max_oa_hr" : 0.0115,
+            "nat_vent_max_oa_rh" : 0.69999999999999996,
+            "nat_vent_num_weekdays" : 3,
+            "nat_vent_num_weekends" : 0,
+            "nat_vent_ovlp_offset" : 1,
+            "nat_vent_ovlp_season" : true,
+            "pier_beam_ach" : 100,
+            "shelter_coef" : "auto",
+            "terrain" : "suburban",
+            "unfinished_attic_sla" : 0.0033300000000000001,
+            "unfinished_basement_ach" : 0.10000000000000001
+         },
+         "description" : "Adds (or replaces) all building components related to airflow: infiltration, mechanical ventilation, natural ventilation, and ducts.",
+         "measure_dir_name" : "ResidentialAirflow",
+         "modeler_description" : "[ModelMeasure] Uses EMS to model the building airflow.",
+         "name" : "Set Residential Airflow"
+      },
+      {
+         "arguments" : {},
+         "description" : "This measure performs HVAC sizing calculations via ACCA Manual J/S, as well as sizing calculations for ground source heat pumps and dehumidifiers.",
+         "measure_dir_name" : "ResidentialHVACSizing",
+         "modeler_description" : "[ModelMeasure] This measure assigns HVAC heating/cooling capacities, airflow rates, etc.",
+         "name" : "Set Residential HVAC Sizing"
+      },
+      {
+         "arguments" : {
+            "azimuth" : 0,
+            "azimuth_type" : "relative",
+            "inverter_efficiency" : 0.95999999999999996,
+            "module_type" : "standard",
+            "size" : 2.5,
+            "system_losses" : 0.14000000000000001,
+            "tilt" : 0,
+            "tilt_type" : "pitch"
+         },
+         "description" : "Adds (or replaces) residential photovoltaics with the specified efficiency, size, orientation, and tilt. For both single-family detached and multifamily buildings, one panel is added (or replaced).",
+         "measure_dir_name" : "ResidentialPhotovoltaics",
+         "modeler_description" : "[ModelMeasure] Any generators and electric load center distribution objects are removed. An electric load center distribution object is added with a track schedule equal to the hourly output from SAM. A micro turbine generator object is add to the electric load center distribution object. The fuel used to make the electricity is zeroed out.",
+         "name" : "Set Residential Photovoltaics"
+      },
+      {
+         "arguments" : {
+            "hpxml_file_path" : "REQUIRED - Absolute (or relative) path of the HPXML file.",
+            "measures_dir" : "REQUIRED - Absolute path of the residential measures.",
+            "weather_file_path" : "Optional - Absolute (or relative) path of the EPW weather file to assign. The corresponding DDY file must also be in the same directory."
+         },
+         "description" : "E+ RESNET",
+         "measure_dir_name" : "HPXMLBuildModel",
+         "modeler_description" : "[ModelMeasure] E+ RESNET",
+         "name" : "HPXML Build Model"
+      },
+      {
+         "arguments" : {
+            "reporting_frequency" : "Hourly"
+         },
+         "description" : "Exports all available hourly timeseries enduses to csv, and uses them for utility bill calculations.",
+         "measure_dir_name" : "TimeseriesCSVExport",
+         "modeler_description" : "[ReportingMeasure] Exports all available hourly timeseries enduses to csv, and uses them for utility bill calculations.",
+         "name" : "Timeseries CSV Export"
+      },
+      {
+         "arguments" : {},
+         "description" : "Calls SAM SDK.",
+         "measure_dir_name" : "UtilityBillCalculations",
+         "modeler_description" : "[ReportingMeasure] Calls SAM SDK.",
+         "name" : "Utility Bill Calculations"
+      }
+   ],
+   "updated_at" : "20170413T133202Z"
+}


### PR DESCRIPTION
## Added `measure-order.json`

It is a JSON file that I created by scraping the README.md table.
It has several groups (‘Location’, ‘Geometry’, etc) and each has a Number of steps, each step has one or more measures. 
**The idea is to organize the measures, and to ultimately define properly the order in which measures are to be run.**

## Rakefile - Generate a Full OSW with all measures

Added a new Rakefile task (`rake generate_full_osw`) that will leverage the `measure-order.json` file to **create an OSW with ALL measures in the correct order**. For each workflow `Step`, the description and modeler description is also included for clarity. Each measure argument is included explicitly, if it has a default value it is used, otherwise there’s a placeholder "#{REQUIRED/OPTIONAL} - #{argument description} ».

Caveat: this OSW file WILL NOT run as is, because it has placeholders (also all measures are included, when you wouldn’t for example both call the three geometry measures for SFA, SFD and MF). 

**Please check the @Todo inside the rakefile**