### PR TITLE
adding availability manager to plant loop

### DIFF
--- a/measures/ResidentialHotWaterSolar/measure.rb
+++ b/measures/ResidentialHotWaterSolar/measure.rb
@@ -412,6 +412,7 @@ class ResidentialHotWaterSolar < OpenStudio::Measure::ModelMeasure
         availability_manager.setColdNode(storage_tank.demandOutletModelObject.get.to_Node.get)
         availability_manager.setTemperatureDifferenceOnLimit(0)
         availability_manager.setTemperatureDifferenceOffLimit(0)
+        plant_loop.setAvailabilityManager(availability_manager)
        
       end
      


### PR DESCRIPTION
This makes the solar hot water measure work with the new availability manager on the plant loop.