### PR TITLE
Fix for MF foundations

### DIFF
--- a/measures/ResidentialAirflow/measure.xml
+++ b/measures/ResidentialAirflow/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_airflow</name>
   <uid>7d2adf5c-9995-49be-b662-a23d2452bb36</uid>
-  <version_id>7198e7d4-2e5c-486f-9e6c-9fe4136dd419</version_id>
-  <version_modified>20181003T150219Z</version_modified>
+  <version_id>b1d5e207-69e8-425a-9768-f90f2ac0b62b</version_id>
+  <version_modified>20181009T182534Z</version_modified>
   <xml_checksum>19EEDBBB</xml_checksum>
   <class_name>ResidentialAirflow</class_name>
   <display_name>Set Residential Airflow</display_name>
@@ -743,12 +743,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -761,96 +755,6 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
-      <filename>SFD_2000sqft_2story_UB_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>DC98FCA6</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>BAA7E1D9</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_ElectricBaseboard.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>237F7678</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>6527997C</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC_Neighbors.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>DD15755A</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC_ElecWHTank_ClothesWasher_ClothesDryer.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>51987C38</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_MSHP.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>D04FEE2E</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_MSHPDucted.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>4A0AA000</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_GRG_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>BD7D87F9</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_SL_GRG_FR_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>708C667B</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_PB_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>65D51A7C</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_FB_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>08526BC6</checksum>
-    </file>
-    <file>
-      <filename>SFD_2000sqft_2story_CS_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>1714DF90</checksum>
-    </file>
-    <file>
-      <filename>SFA_4units_1story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>36BDC518</checksum>
-    </file>
-    <file>
-      <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F12AF533</checksum>
-    </file>
-    <file>
       <filename>airflow.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -861,6 +765,102 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_UB_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>99127E91</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>73F0F64A</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_ElectricBaseboard.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DE238172</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>190F9762</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC_Neighbors.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>2A101665</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC_ElecWHTank_ClothesWasher_ClothesDryer.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CB876C37</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_MSHP.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F9174BD9</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_MSHPDucted.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>EF42F660</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_GRG_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>CF0A76A6</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_GRG_FR_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>8F1AB328</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_PB_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>B206E668</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_FB_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>77C810EC</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_CS_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>FE7E622A</checksum>
+    </file>
+    <file>
+      <filename>SFA_4units_1story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>8BE3C876</checksum>
+    </file>
+    <file>
+      <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>D0AF62D3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialAirflow/resources/geometry.rb
+++ b/measures/ResidentialAirflow/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialApplianceClothesDryer/measure.xml
+++ b/measures/ResidentialApplianceClothesDryer/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_clothes_dryer</name>
   <uid>0ed6fb35-c3e0-4a33-a397-ce4cec92d96e</uid>
-  <version_id>6d0a4133-4dda-4112-a383-7cc4cfee70b4</version_id>
-  <version_modified>20181003T150219Z</version_modified>
+  <version_id>5271b92b-08dc-4959-9c69-964b529fad2e</version_id>
+  <version_modified>20181009T182534Z</version_modified>
   <xml_checksum>25A40D75</xml_checksum>
   <class_name>ResidentialClothesDryer</class_name>
   <display_name>Set Residential Clothes Dryer</display_name>
@@ -186,12 +186,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -204,40 +198,46 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_ClothesWasher.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0DCAD5AE</checksum>
+      <checksum>A20363CF</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F55039A</checksum>
+      <checksum>72FFE927</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_UB_UA_3Beds_2Baths_Denver_WHTank_ClothesWasher.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AEB4DA94</checksum>
+      <checksum>EBDD0F3A</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver_WHTank_ClothesWasher.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DFC46D25</checksum>
+      <checksum>CB4EE3D3</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_WHTank_ClothesWasher.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AF24ACC</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>CF52FE55</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialApplianceClothesDryer/resources/geometry.rb
+++ b/measures/ResidentialApplianceClothesDryer/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialApplianceClothesWasher/measure.xml
+++ b/measures/ResidentialApplianceClothesWasher/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_clothes_washer</name>
   <uid>640bfdca-ba67-461e-b517-1a7291c22b22</uid>
-  <version_id>bea8fa61-33d1-4790-87b5-70a81b657048</version_id>
-  <version_modified>20181003T150219Z</version_modified>
+  <version_id>9d6c3c47-8253-4651-95f7-379e2f0fa781</version_id>
+  <version_modified>20181009T182535Z</version_modified>
   <xml_checksum>126F1C43</xml_checksum>
   <class_name>ResidentialClothesWasher</class_name>
   <display_name>Set Residential Clothes Washer</display_name>
@@ -313,12 +313,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -331,64 +325,70 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_ClothesWasher_ElecClothesDryer.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9B8C41</checksum>
+      <checksum>FCAB5A4E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_ClothesWasher_GasClothesDryer.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AC9E5BA2</checksum>
+      <checksum>E92ADD96</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_ClothesWasher_PropaneClothesDryer.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F40333D3</checksum>
+      <checksum>21E9D54F</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2C93F17D</checksum>
+      <checksum>3B6B17B5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>08F3C449</checksum>
+      <checksum>CD9E7AE8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTankless.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7AA30BD7</checksum>
+      <checksum>6105A249</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_UB_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>42992A56</checksum>
+      <checksum>2FBABBAB</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE9C3C0E</checksum>
+      <checksum>61BE628A</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BDC0A200</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>EBC562C9</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialApplianceClothesWasher/resources/geometry.rb
+++ b/measures/ResidentialApplianceClothesWasher/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialApplianceCookingRange/measure.xml
+++ b/measures/ResidentialApplianceCookingRange/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_cooking_range</name>
   <uid>68bdcee3-c301-4fe9-a99f-c7d8b5930c89</uid>
-  <version_id>f20bdb95-4f93-42eb-a012-63c5a3c43969</version_id>
-  <version_modified>20181003T150219Z</version_modified>
+  <version_id>f67b3e85-5e9f-48ea-85ea-70553ca6f933</version_id>
+  <version_modified>20181009T182535Z</version_modified>
   <xml_checksum>25A40D75</xml_checksum>
   <class_name>ResidentialCookingRange</class_name>
   <display_name>Set Residential Cooking Range</display_name>
@@ -194,12 +194,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -212,34 +206,40 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F55039A</checksum>
+      <checksum>72FFE927</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_UB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4FA2C21D</checksum>
+      <checksum>12ED99F2</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D49235FC</checksum>
+      <checksum>E04DAF60</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1B63556F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>3A8AE4C3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialApplianceCookingRange/resources/geometry.rb
+++ b/measures/ResidentialApplianceCookingRange/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialApplianceDishwasher/measure.xml
+++ b/measures/ResidentialApplianceDishwasher/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_dishwasher</name>
   <uid>09ea4570-4666-4a55-812f-5e90091f5325</uid>
-  <version_id>44757fd8-3179-4b7f-a434-d45b0522c7f6</version_id>
-  <version_modified>20181003T150220Z</version_modified>
+  <version_id>bde800bc-deb6-4054-82a2-15708445b2af</version_id>
+  <version_modified>20181009T182535Z</version_modified>
   <xml_checksum>126F1C43</xml_checksum>
   <class_name>ResidentialDishwasher</class_name>
   <display_name>Set Residential Dishwasher</display_name>
@@ -275,12 +275,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -293,46 +287,52 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2C93F17D</checksum>
+      <checksum>3B6B17B5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>08F3C449</checksum>
+      <checksum>CD9E7AE8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTankless.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7AA30BD7</checksum>
+      <checksum>6105A249</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_UB_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>42992A56</checksum>
+      <checksum>2FBABBAB</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE9C3C0E</checksum>
+      <checksum>61BE628A</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BDC0A200</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>EBC562C9</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialApplianceDishwasher/resources/geometry.rb
+++ b/measures/ResidentialApplianceDishwasher/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialApplianceRefrigerator/measure.xml
+++ b/measures/ResidentialApplianceRefrigerator/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_refrigerator</name>
   <uid>f0259bdc-1391-41eb-80eb-efc10bd1bc02</uid>
-  <version_id>7ebd2da0-3be9-40e2-be95-54cc834d65d5</version_id>
-  <version_modified>20181003T150220Z</version_modified>
+  <version_id>c7c59db2-11f1-4b03-acb5-5663cf6f932a</version_id>
+  <version_modified>20181009T182535Z</version_modified>
   <xml_checksum>126F1C43</xml_checksum>
   <class_name>ResidentialRefrigerator</class_name>
   <display_name>Set Residential Refrigerator</display_name>
@@ -144,12 +144,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>appliances.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -162,34 +156,40 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>002D13D0</checksum>
+      <checksum>4227BD92</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_UB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4FA2C21D</checksum>
+      <checksum>12ED99F2</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D49235FC</checksum>
+      <checksum>E04DAF60</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1B63556F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>3A8AE4C3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialApplianceRefrigerator/resources/geometry.rb
+++ b/measures/ResidentialApplianceRefrigerator/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsCrawlspace/measure.xml
+++ b/measures/ResidentialConstructionsCrawlspace/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_crawlspace</name>
   <uid>c30a490e-4ff6-4fe9-88ae-a949421a287d</uid>
-  <version_id>8e11bd63-2c7c-4b76-8301-c62db55b624f</version_id>
-  <version_modified>20181003T150220Z</version_modified>
+  <version_id>3a79b387-628f-434e-af90-b981ec4d8eef</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsCrawlspace</class_name>
   <display_name>Set Residential Crawlspace Constructions</display_name>
@@ -144,40 +144,40 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_CS_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>578E86F6</checksum>
+      <checksum>BAB4670B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_CS_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B0992016</checksum>
+      <checksum>54831FB3</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_CS_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>28C1331E</checksum>
+      <checksum>C4F45E4A</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_CS_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>80DE6383</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>0E16FDC5</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsCrawlspace/resources/geometry.rb
+++ b/measures/ResidentialConstructionsCrawlspace/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsDoors/measure.xml
+++ b/measures/ResidentialConstructionsDoors/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_doors</name>
   <uid>b78f10fa-b38d-4de2-86e9-344a78e68847</uid>
-  <version_id>292a751e-73c8-4713-bf4e-5ea68cd5d94a</version_id>
-  <version_modified>20181003T150220Z</version_modified>
+  <version_id>9c6323f2-7216-4180-a117-4e4f2e38850a</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>6FAFA9DE</xml_checksum>
   <class_name>ProcessConstructionsDoors</class_name>
   <display_name>Set Residential Door Construction</display_name>
@@ -81,22 +81,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_GRG_UA_Windows_Doors.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F0B9ABB1</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>F79055B7</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsDoors/resources/geometry.rb
+++ b/measures/ResidentialConstructionsDoors/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsFinishedBasement/measure.xml
+++ b/measures/ResidentialConstructionsFinishedBasement/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_finished_basement</name>
   <uid>4b37c726-d6c4-473b-990a-0923c302ed36</uid>
-  <version_id>ebcf6783-35c4-4e02-894b-215fb43268f0</version_id>
-  <version_modified>20181003T150220Z</version_modified>
+  <version_id>ce08ec9b-002f-492b-8041-040e9a422340</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsFinishedBasement</class_name>
   <display_name>Set Residential Finished Basement Constructions</display_name>
@@ -183,40 +183,40 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_1000sqft_1story_FB_GRG_UA_DoorArea.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>409374DD</checksum>
+      <checksum>881DC472</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E1E9508F</checksum>
+      <checksum>80C6E64E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>002D13D0</checksum>
+      <checksum>4227BD92</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D49235FC</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>E04DAF60</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsFinishedBasement/resources/geometry.rb
+++ b/measures/ResidentialConstructionsFinishedBasement/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsFinishedRoof/measure.xml
+++ b/measures/ResidentialConstructionsFinishedRoof/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_finished_roof</name>
   <uid>6349eb9b-6e7e-4ba9-b518-76d2f9f73c79</uid>
-  <version_id>4a3e8249-2748-4e59-9ec4-2f43996f8bab</version_id>
-  <version_modified>20181003T150220Z</version_modified>
+  <version_id>6872a470-cd11-4f97-9a76-70d4d23cfd93</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsFinishedRoof</class_name>
   <display_name>Set Residential Finished Roof Construction</display_name>
@@ -236,22 +236,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_FA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B851A4B8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>F17381C5</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsFinishedRoof/resources/geometry.rb
+++ b/measures/ResidentialConstructionsFinishedRoof/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsFloors/measure.xml
+++ b/measures/ResidentialConstructionsFloors/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_floors</name>
   <uid>65e577ab-327e-4afa-af30-0f6b4e6b1ebf</uid>
-  <version_id>f85164a9-f2eb-49c5-b1cc-707e0829f360</version_id>
-  <version_modified>20181003T150221Z</version_modified>
+  <version_id>a98d4f59-cf0b-4806-b019-18dad040cbd6</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsFloors</class_name>
   <display_name>Set Residential Floor Construction</display_name>
@@ -124,22 +124,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9C37C7B5</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>D033DD13</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsFloors/resources/geometry.rb
+++ b/measures/ResidentialConstructionsFloors/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsPierBeam/measure.xml
+++ b/measures/ResidentialConstructionsPierBeam/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_pier_beam</name>
   <uid>c47f2fc2-008e-403c-82e6-fd751b4f3b8a</uid>
-  <version_id>1ccc2a5e-e363-4d74-8e09-4c7ca3450297</version_id>
-  <version_modified>20181003T150221Z</version_modified>
+  <version_id>d9a35129-0b60-4a80-9e07-fe672f237a38</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsPierBeam</class_name>
   <display_name>Set Residential Pier &amp; Beam Construction</display_name>
@@ -124,22 +124,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_PB_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FAEFE1DB</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>C7E3787B</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsPierBeam/resources/geometry.rb
+++ b/measures/ResidentialConstructionsPierBeam/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsSlab/measure.xml
+++ b/measures/ResidentialConstructionsSlab/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_slab</name>
   <uid>4fd36916-5b69-43d2-a7bb-e7fad34508db</uid>
-  <version_id>079297a4-1a1b-4ea1-ade6-4a871189343d</version_id>
-  <version_modified>20181003T150221Z</version_modified>
+  <version_id>ac145a2d-ead7-441b-a3d9-30e51080b72c</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsSlab</class_name>
   <display_name>Set Residential Slab Construction</display_name>
@@ -131,46 +131,46 @@
       <checksum>BD0ED407</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_GRG_UA_Windows_Doors.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F0B9ABB1</checksum>
+      <checksum>F79055B7</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0768058A</checksum>
+      <checksum>A685927B</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_SL_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BD150A29</checksum>
+      <checksum>7BBC12E6</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9C37C7B5</checksum>
+      <checksum>D033DD13</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1B63556F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>3A8AE4C3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsSlab/resources/geometry.rb
+++ b/measures/ResidentialConstructionsSlab/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsUnfinishedAttic/measure.xml
+++ b/measures/ResidentialConstructionsUnfinishedAttic/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_unfinished_attic</name>
   <uid>235ba3ce-dd83-4287-aa0e-435dc1cbf1a7</uid>
-  <version_id>e5ce13e4-b642-45bc-9182-03ae79d21092</version_id>
-  <version_modified>20181003T150221Z</version_modified>
+  <version_id>69a1d587-8440-4b5e-9df7-dcfd95b75a3a</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsUnfinishedAttic</class_name>
   <display_name>Set Residential Unfinished Attic Constructions</display_name>
@@ -309,22 +309,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsUnfinishedAttic/resources/geometry.rb
+++ b/measures/ResidentialConstructionsUnfinishedAttic/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsUnfinishedBasement/measure.xml
+++ b/measures/ResidentialConstructionsUnfinishedBasement/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_unfinished_basement</name>
   <uid>ebc21070-2d4b-4a2a-bd15-f18bf3e77b49</uid>
-  <version_id>54b92511-9b53-4843-81aa-036f0971c47d</version_id>
-  <version_modified>20181003T150221Z</version_modified>
+  <version_id>65f9ea9e-a83f-406c-8871-7d86a491a4ca</version_id>
+  <version_modified>20181009T182536Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsUnfinishedBasement</class_name>
   <display_name>Set Residential Unfinished Basement Constructions</display_name>
@@ -236,40 +236,40 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_UB_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96275209</checksum>
+      <checksum>3ACC1DBF</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_UB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4FA2C21D</checksum>
+      <checksum>12ED99F2</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_UB_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E41ECAF0</checksum>
+      <checksum>292A9AD5</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_UB_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3F7A623C</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>1153ADFA</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsUnfinishedBasement/resources/geometry.rb
+++ b/measures/ResidentialConstructionsUnfinishedBasement/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsWallsCMU/measure.xml
+++ b/measures/ResidentialConstructionsWallsCMU/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_walls_cmu</name>
   <uid>64c320f1-6e42-4f15-8946-8ca3e5314dd9</uid>
-  <version_id>69f36669-b747-4314-9ff5-568474165e78</version_id>
-  <version_modified>20181003T150221Z</version_modified>
+  <version_id>c5172145-6036-486e-8ed6-0b5145892b42</version_id>
+  <version_modified>20181009T182537Z</version_modified>
   <xml_checksum>2609226D</xml_checksum>
   <class_name>ProcessConstructionsWallsCMU</class_name>
   <display_name>Set Residential Walls - CMU Construction</display_name>
@@ -236,22 +236,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_CeilingIns.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F7E8C409</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>864FBCB8</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsWallsCMU/resources/geometry.rb
+++ b/measures/ResidentialConstructionsWallsCMU/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsWallsDoubleWoodStud/measure.xml
+++ b/measures/ResidentialConstructionsWallsDoubleWoodStud/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_walls_double_wood_stud</name>
   <uid>d3ae8875-36bc-4e4f-a5a9-c9d0dcd46651</uid>
-  <version_id>5971eb4b-7913-4602-84e8-dd37516ddbe5</version_id>
-  <version_modified>20181003T150221Z</version_modified>
+  <version_id>f9bfcb65-0495-4e37-bf1a-3f4cd8b22c69</version_id>
+  <version_modified>20181009T182537Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsWallsDoubleWoodStud</class_name>
   <display_name>Set Residential Walls - Double Wood Stud Construction</display_name>
@@ -248,22 +248,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_CeilingIns.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F7E8C409</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>864FBCB8</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsWallsDoubleWoodStud/resources/geometry.rb
+++ b/measures/ResidentialConstructionsWallsDoubleWoodStud/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsWallsGeneric/measure.xml
+++ b/measures/ResidentialConstructionsWallsGeneric/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_walls_generic</name>
   <uid>d7572e51-b9af-4cb3-b984-7c8d0a7e0e73</uid>
-  <version_id>c86a7094-659d-4903-957c-ebf8ea758928</version_id>
-  <version_modified>20181003T150221Z</version_modified>
+  <version_id>f8cb40b5-832d-460c-be08-8c409f3b4e0e</version_id>
+  <version_modified>20181009T182537Z</version_modified>
   <xml_checksum>5091078B</xml_checksum>
   <class_name>ProcessConstructionsWallsGeneric</class_name>
   <display_name>Set Residential Walls - Generic Construction</display_name>
@@ -340,22 +340,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_CeilingIns.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F7E8C409</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>864FBCB8</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsWallsGeneric/resources/geometry.rb
+++ b/measures/ResidentialConstructionsWallsGeneric/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsWallsICF/measure.xml
+++ b/measures/ResidentialConstructionsWallsICF/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_walls_icf</name>
   <uid>41d87ab7-8f06-4b12-b0b6-61ccbe8887e3</uid>
-  <version_id>26bdd230-d430-4dd5-9422-5cd3955381e5</version_id>
-  <version_modified>20181003T150222Z</version_modified>
+  <version_id>d93502fa-c663-464d-9472-b87c57bcf9d7</version_id>
+  <version_modified>20181009T182537Z</version_modified>
   <xml_checksum>2609226D</xml_checksum>
   <class_name>ProcessConstructionsWallsICF</class_name>
   <display_name>Set Residential Walls - ICF Construction</display_name>
@@ -206,22 +206,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_CeilingIns.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F7E8C409</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>864FBCB8</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsWallsICF/resources/geometry.rb
+++ b/measures/ResidentialConstructionsWallsICF/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsWallsSIP/measure.xml
+++ b/measures/ResidentialConstructionsWallsSIP/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_walls_sip</name>
   <uid>d3c6d46a-2ebe-41a9-b218-d4c2a7d0f530</uid>
-  <version_id>b7e988d1-18dc-45b9-820b-5d60ed140e7a</version_id>
-  <version_modified>20181003T150222Z</version_modified>
+  <version_id>666e9162-0d4b-4bb5-8f40-0cde36e8693e</version_id>
+  <version_modified>20181009T182537Z</version_modified>
   <xml_checksum>2609226D</xml_checksum>
   <class_name>ProcessConstructionsWallsSIP</class_name>
   <display_name>Set Residential Walls - SIP Construction</display_name>
@@ -229,22 +229,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_CeilingIns.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F7E8C409</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>864FBCB8</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsWallsSIP/resources/geometry.rb
+++ b/measures/ResidentialConstructionsWallsSIP/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsWallsSteelStud/measure.xml
+++ b/measures/ResidentialConstructionsWallsSteelStud/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_walls_steel_stud</name>
   <uid>1ff01961-2d80-4074-90ea-84c56a7204be</uid>
-  <version_id>14404946-bfe8-426f-885f-5d212922ae95</version_id>
-  <version_modified>20181003T150222Z</version_modified>
+  <version_id>eee11ba0-4647-401a-bc23-080dbc101ced</version_id>
+  <version_modified>20181009T182537Z</version_modified>
   <xml_checksum>2609226D</xml_checksum>
   <class_name>ProcessConstructionsWallsSteelStud</class_name>
   <display_name>Set Residential Walls - Steel Stud Construction</display_name>
@@ -247,22 +247,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_CeilingIns.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F7E8C409</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>864FBCB8</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsWallsSteelStud/resources/geometry.rb
+++ b/measures/ResidentialConstructionsWallsSteelStud/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsWallsWoodStud/measure.xml
+++ b/measures/ResidentialConstructionsWallsWoodStud/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_walls_wood_stud</name>
   <uid>76193c5c-d1a6-4a57-864a-c8a32e67adcb</uid>
-  <version_id>4cb51d9a-eb5b-46ec-bfbc-e977b15d40b4</version_id>
-  <version_modified>20181003T150223Z</version_modified>
+  <version_id>8d95cdbb-e91b-4003-8c1a-9ef330806f6a</version_id>
+  <version_modified>20181009T182537Z</version_modified>
   <xml_checksum>1E963D9C</xml_checksum>
   <class_name>ProcessConstructionsWallsWoodStud</class_name>
   <display_name>Set Residential Walls - Wood Stud Construction</display_name>
@@ -228,22 +228,22 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_CeilingIns.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F7E8C409</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>864FBCB8</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsWallsWoodStud/resources/geometry.rb
+++ b/measures/ResidentialConstructionsWallsWoodStud/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialConstructionsWindowsSkylights/measure.xml
+++ b/measures/ResidentialConstructionsWindowsSkylights/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_constructions_windows_skylights</name>
   <uid>648dc42f-f079-4d97-913e-6dc3e19560b1</uid>
-  <version_id>8a825f9e-eda1-4867-ad4b-63fe906cac51</version_id>
-  <version_modified>20181003T150223Z</version_modified>
+  <version_id>3dce4c80-35bd-4105-9200-0e21dd116161</version_id>
+  <version_modified>20181009T182538Z</version_modified>
   <xml_checksum>6FAFA9DE</xml_checksum>
   <class_name>ProcessConstructionsWindowsSkylights</class_name>
   <display_name>Set Residential Window/Skylight Construction</display_name>
@@ -169,12 +169,6 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -187,28 +181,34 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Windows.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4B640212</checksum>
+      <checksum>30F6E459</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver_Windows.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1304FD73</checksum>
+      <checksum>9833E07F</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_FA_Denver_Windows_Skylights.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BD393CD5</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>69B34DF4</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialConstructionsWindowsSkylights/resources/geometry.rb
+++ b/measures/ResidentialConstructionsWindowsSkylights/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialGeometryCreateFromFloorspaceJS/measure.xml
+++ b/measures/ResidentialGeometryCreateFromFloorspaceJS/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_geometry_from_floorspace_js</name>
   <uid>79d7fbb8-e001-4c65-9444-c7dcb975290f</uid>
-  <version_id>f6106440-b895-4e22-b75a-278e5501cddb</version_id>
-  <version_modified>20181003T150223Z</version_modified>
+  <version_id>c0d2582b-3e7d-4df6-8f1e-4dc9dc8de9c4</version_id>
+  <version_modified>20181009T182538Z</version_modified>
   <xml_checksum>0AD1E2E2</xml_checksum>
   <class_name>ResidentialGeometryFromFloorspaceJS</class_name>
   <display_name>Residential Geometry from FloorspaceJS</display_name>
@@ -17,7 +17,7 @@
       <type>String</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value>C:/GitHub/OpenStudio-BEopt/measures/ResidentialGeometryCreateFromFloorspaceJS/tests/SFD_Multizone.json</default_value>
+      <default_value>C:/GitHub/OpenStudio-BEopt-master/measures/ResidentialGeometryCreateFromFloorspaceJS/tests/SFD_Multizone.json</default_value>
     </argument>
     <argument>
       <name>num_bedrooms</name>
@@ -251,12 +251,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -267,6 +261,12 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialGeometryCreateFromFloorspaceJS/resources/geometry.rb
+++ b/measures/ResidentialGeometryCreateFromFloorspaceJS/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialGeometryCreateMultifamily/measure.xml
+++ b/measures/ResidentialGeometryCreateMultifamily/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>create_residential_multifamily_geometry</name>
   <uid>9bc07973-98a4-46fc-b643-e280628817c5</uid>
-  <version_id>5acf69e9-a019-4fcd-ba12-317745612f19</version_id>
-  <version_modified>20181003T150223Z</version_modified>
+  <version_id>4c407cc5-8241-41f5-9cc3-8bb3e51f6927</version_id>
+  <version_modified>20181009T182538Z</version_modified>
   <xml_checksum>2AF3A68E</xml_checksum>
   <class_name>CreateResidentialMultifamilyGeometry</class_name>
   <display_name>Create Residential Multifamily Geometry</display_name>
@@ -329,33 +329,10 @@
       <checksum>4516079E</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>1.12.2</identifier>
-        <min_compatible>2.0.4</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>2B8DE8E8</checksum>
-    </file>
-    <file>
-      <filename>create_residential_multifamily_geometry_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>5A1220E9</checksum>
-    </file>
-    <file>
       <filename>unit_conversions.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>81550F14</checksum>
-    </file>
-    <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
     </file>
     <file>
       <filename>schedules.rb</filename>
@@ -364,16 +341,39 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
-      <filename>MF_8units_1story_SL_Denver.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>1.12.2</identifier>
+        <min_compatible>2.0.4</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>7025EDF1</checksum>
+    </file>
+    <file>
+      <filename>create_residential_multifamily_geometry_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>FE5E18A1</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
+      <filename>MF_8units_1story_SL_Denver.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialGeometryCreateMultifamily/resources/geometry.rb
+++ b/measures/ResidentialGeometryCreateMultifamily/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialGeometryCreateSingleFamilyAttached/measure.xml
+++ b/measures/ResidentialGeometryCreateSingleFamilyAttached/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>create_residential_single_family_attached_geometry</name>
   <uid>fb4e4db8-1b29-4cbf-abcd-6af194ad945c</uid>
-  <version_id>be62f7a6-6490-4337-bb9c-d0ac2b65b479</version_id>
-  <version_modified>20181003T150224Z</version_modified>
+  <version_id>da97070b-b629-4660-80f4-a700ae788458</version_id>
+  <version_modified>20181009T182538Z</version_modified>
   <xml_checksum>2AF3A68E</xml_checksum>
   <class_name>CreateResidentialSingleFamilyAttachedGeometry</class_name>
   <display_name>Create Residential Single-Family Attached Geometry</display_name>
@@ -419,28 +419,28 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
-      <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
-    </file>
-    <file>
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
+      <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>0647E240</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialGeometryCreateSingleFamilyAttached/resources/geometry.rb
+++ b/measures/ResidentialGeometryCreateSingleFamilyAttached/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialGeometryCreateSingleFamilyDetached/measure.xml
+++ b/measures/ResidentialGeometryCreateSingleFamilyDetached/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>create_residential_single_family_detached_geometry</name>
   <uid>a1248ef4-c1ef-46ed-a9ea-4d8fbf719b6f</uid>
-  <version_id>090fe9cb-feeb-489d-8c6b-3ee3f19742dd</version_id>
-  <version_modified>20181003T150224Z</version_modified>
+  <version_id>b2e8dea7-3cd4-46e2-a5d8-78a25d207e2c</version_id>
+  <version_modified>20181009T182538Z</version_modified>
   <xml_checksum>2AF3A68E</xml_checksum>
   <class_name>CreateResidentialSingleFamilyDetachedGeometry</class_name>
   <display_name>Create Residential Single-Family Detached Geometry</display_name>
@@ -433,28 +433,28 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
-      <filename>SFD_2000sqft_2story_SL_UA.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>0768058A</checksum>
-    </file>
-    <file>
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
+      <filename>SFD_2000sqft_2story_SL_UA.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A685927B</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialGeometryCreateSingleFamilyDetached/resources/geometry.rb
+++ b/measures/ResidentialGeometryCreateSingleFamilyDetached/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialGeometryDoorArea/measure.xml
+++ b/measures/ResidentialGeometryDoorArea/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>create_residential_door_area</name>
   <uid>901a04ee-99d4-42b3-91e1-b5b97970f441</uid>
-  <version_id>b010ce3e-2613-4874-a95b-d5c02f1d91f8</version_id>
-  <version_modified>20181003T150224Z</version_modified>
+  <version_id>8ad578e7-b847-4591-99cc-83c8dc6002d9</version_id>
+  <version_modified>20181009T182538Z</version_modified>
   <xml_checksum>9C8A26EB</xml_checksum>
   <class_name>CreateResidentialDoorArea</class_name>
   <display_name>Set Residential Door Area</display_name>
@@ -79,52 +79,52 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_GRG_UA_Doors_OneConstruction.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>80FC41EA</checksum>
+      <checksum>76F3692C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_Southwest.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4DE6C1D4</checksum>
+      <checksum>5E0920C1</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>002D13D0</checksum>
+      <checksum>4227BD92</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver_ExteriorCorridor.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>22F6FCD1</checksum>
+      <checksum>925D67CD</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialGeometryDoorArea/resources/geometry.rb
+++ b/measures/ResidentialGeometryDoorArea/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialGeometryWindowSkylightArea/measure.xml
+++ b/measures/ResidentialGeometryWindowSkylightArea/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>set_residential_window_skylight_area</name>
   <uid>d05f5b32-1ad6-4c3d-964a-0dbd49a7fde8</uid>
-  <version_id>7d463a20-dbb7-4cff-a45f-40877cb96175</version_id>
-  <version_modified>20181003T150224Z</version_modified>
+  <version_id>67e1b5a7-5852-4806-bed0-61c7d1f13b8a</version_id>
+  <version_modified>20181009T182538Z</version_modified>
   <xml_checksum>9014E219</xml_checksum>
   <class_name>SetResidentialWindowSkylightArea</class_name>
   <display_name>Set Residential Window/Skylight Area</display_name>
@@ -297,88 +297,88 @@
       <checksum>C34B5382</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver_Windows_OneConstruction.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DAF81425</checksum>
+      <checksum>EBB8E212</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_FA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B851A4B8</checksum>
+      <checksum>F17381C5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_FA_LeftRight.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>A02F4C3C</checksum>
+      <checksum>A52B8A8F</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_FA_FlatRoof.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>912B31B7</checksum>
+      <checksum>39EC9709</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_FA_HipRoof.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>16042B39</checksum>
+      <checksum>88A7A6E1</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_Southwest.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4DE6C1D4</checksum>
+      <checksum>5E0920C1</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>002D13D0</checksum>
+      <checksum>4227BD92</checksum>
     </file>
     <file>
       <filename>SFD_1000sqft_1story_FB_GRG_UA_DoorArea.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>409374DD</checksum>
+      <checksum>881DC472</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_SL_UA_Offset.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D85CA6A2</checksum>
+      <checksum>C4502D4D</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Inset.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>6F2BA4BF</checksum>
+      <checksum>2CC9FA6B</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialGeometryWindowSkylightArea/resources/geometry.rb
+++ b/measures/ResidentialGeometryWindowSkylightArea/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACAirSourceHeatPumpSingleSpeed/measure.xml
+++ b/measures/ResidentialHVACAirSourceHeatPumpSingleSpeed/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_single_speed_air_source_heat_pump</name>
   <uid>9f709cf6-cf55-4bb3-8087-7a5c5a98aa7c</uid>
-  <version_id>f822ea06-1d55-4c17-bee0-261bda42374d</version_id>
-  <version_modified>20181003T150225Z</version_modified>
+  <version_id>1251e134-8569-44be-b778-fe298e169e61</version_id>
+  <version_modified>20181009T182540Z</version_modified>
   <xml_checksum>0DA5C9E6</xml_checksum>
   <class_name>ProcessSingleSpeedAirSourceHeatPump</class_name>
   <display_name>Set Residential Single-Speed Air Source Heat Pump</display_name>
@@ -311,12 +311,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -329,154 +323,160 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACAirSourceHeatPumpSingleSpeed/resources/geometry.rb
+++ b/measures/ResidentialHVACAirSourceHeatPumpSingleSpeed/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACAirSourceHeatPumpTwoSpeed/measure.xml
+++ b/measures/ResidentialHVACAirSourceHeatPumpTwoSpeed/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_two_speed_air_source_heat_pump</name>
   <uid>e1fa8fdd-4940-4364-b3ea-3bc6b93ca9c4</uid>
-  <version_id>ad6580a2-2f10-48c8-9263-af973fa3f7d8</version_id>
-  <version_modified>20181003T150226Z</version_modified>
+  <version_id>9799ccf6-f1ae-465a-8968-f0cc0a9a773d</version_id>
+  <version_modified>20181009T182540Z</version_modified>
   <xml_checksum>470FC630</xml_checksum>
   <class_name>ProcessTwoSpeedAirSourceHeatPump</class_name>
   <display_name>Set Residential Two-Speed Air Source Heat Pump</display_name>
@@ -404,12 +404,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -422,154 +416,160 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACAirSourceHeatPumpTwoSpeed/resources/geometry.rb
+++ b/measures/ResidentialHVACAirSourceHeatPumpTwoSpeed/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACAirSourceHeatPumpVariableSpeed/measure.xml
+++ b/measures/ResidentialHVACAirSourceHeatPumpVariableSpeed/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_variable_speed_air_source_heat_pump</name>
   <uid>8d15f4f7-8bbb-4b2e-b6d0-aa861f22b697</uid>
-  <version_id>21e3f6fd-28cb-454b-a110-fb146b0eab5c</version_id>
-  <version_modified>20181003T150226Z</version_modified>
+  <version_id>a8257e5f-d0b3-49a5-b140-82257a046a21</version_id>
+  <version_modified>20181009T182540Z</version_modified>
   <xml_checksum>470FC630</xml_checksum>
   <class_name>ProcessVariableSpeedAirSourceHeatPump</class_name>
   <display_name>Set Residential Variable-Speed Air Source Heat Pump</display_name>
@@ -516,12 +516,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -534,154 +528,160 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACAirSourceHeatPumpVariableSpeed/resources/geometry.rb
+++ b/measures/ResidentialHVACAirSourceHeatPumpVariableSpeed/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACBoiler/measure.xml
+++ b/measures/ResidentialHVACBoiler/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_boiler</name>
   <uid>42909b35-edc9-41b3-ba59-de138eac3c85</uid>
-  <version_id>2cc5c813-af43-4fed-a477-951b37b15c23</version_id>
-  <version_modified>20181003T150226Z</version_modified>
+  <version_id>8bf1450d-f044-42a7-bfd5-de2d3469d7e0</version_id>
+  <version_modified>20181009T182540Z</version_modified>
   <xml_checksum>470FC630</xml_checksum>
   <class_name>ProcessBoiler</class_name>
   <display_name>Set Residential Boiler</display_name>
@@ -256,12 +256,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -274,142 +268,148 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACBoiler/resources/geometry.rb
+++ b/measures/ResidentialHVACBoiler/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACCeilingFan/measure.xml
+++ b/measures/ResidentialHVACCeilingFan/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_ceiling_fan</name>
   <uid>f65edfd9-ff4f-4f08-a245-ea48b3b3c88e</uid>
-  <version_id>0a4cfc39-a013-44dd-b8c4-7fbbf3d6322f</version_id>
-  <version_modified>20181003T150226Z</version_modified>
+  <version_id>d245d6d0-c459-4b92-9ae8-ab7a612a2a61</version_id>
+  <version_modified>20181009T182540Z</version_modified>
   <xml_checksum>D48F381B</xml_checksum>
   <class_name>ProcessCeilingFan</class_name>
   <display_name>Set Residential Ceiling Fan</display_name>
@@ -195,12 +195,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -213,40 +207,46 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BAA7E1D9</checksum>
+      <checksum>73F0F64A</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>08526BC6</checksum>
+      <checksum>77C810EC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_3Beds_2Baths_Denver_Furnace_CentralAC_VarTstat.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9DB8D19F</checksum>
+      <checksum>7F00616D</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>36BDC518</checksum>
+      <checksum>8BE3C876</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F12AF533</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>D0AF62D3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACCeilingFan/resources/geometry.rb
+++ b/measures/ResidentialHVACCeilingFan/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACCentralAirConditionerSingleSpeed/measure.xml
+++ b/measures/ResidentialHVACCentralAirConditionerSingleSpeed/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_single_speed_central_air_conditioner</name>
   <uid>62ef17da-be70-43a1-99ec-b000e016ba4a</uid>
-  <version_id>53b7ee6c-9ffb-4b76-828a-b0db55c6e358</version_id>
-  <version_modified>20181003T150226Z</version_modified>
+  <version_id>0cef3bf4-aaa3-446d-a48c-337855a6431e</version_id>
+  <version_modified>20181009T182541Z</version_modified>
   <xml_checksum>9E2537CD</xml_checksum>
   <class_name>ProcessSingleSpeedCentralAirConditioner</class_name>
   <display_name>Set Residential Single-Speed Central Air Conditioner</display_name>
@@ -216,12 +216,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -234,154 +228,160 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACCentralAirConditionerSingleSpeed/resources/geometry.rb
+++ b/measures/ResidentialHVACCentralAirConditionerSingleSpeed/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACCentralAirConditionerTwoSpeed/measure.xml
+++ b/measures/ResidentialHVACCentralAirConditionerTwoSpeed/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_two_speed_central_air_conditioner</name>
   <uid>fd979c79-79d9-4c99-8cc8-abd7935d636b</uid>
-  <version_id>cc0df4e9-8252-4683-b50c-e7f7fb033869</version_id>
-  <version_modified>20181003T150227Z</version_modified>
+  <version_id>4d099776-05ea-42de-8b02-77a25dfa0978</version_id>
+  <version_modified>20181009T182541Z</version_modified>
   <xml_checksum>D48F381B</xml_checksum>
   <class_name>ProcessTwoSpeedCentralAirConditioner</class_name>
   <display_name>Set Residential Two-Speed Central Air Conditioner</display_name>
@@ -281,12 +281,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -299,154 +293,160 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACCentralAirConditionerTwoSpeed/resources/geometry.rb
+++ b/measures/ResidentialHVACCentralAirConditionerTwoSpeed/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACCentralAirConditionerVariableSpeed/measure.xml
+++ b/measures/ResidentialHVACCentralAirConditionerVariableSpeed/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_variable_speed_central_air_conditioner</name>
   <uid>7387af85-5ae2-422c-9488-d64b8682dd06</uid>
-  <version_id>02973387-37e1-48b4-8b0c-09cb729827d4</version_id>
-  <version_modified>20181003T150227Z</version_modified>
+  <version_id>62dd301c-cb91-47fb-aee0-f370cea4f1ad</version_id>
+  <version_modified>20181009T182541Z</version_modified>
   <xml_checksum>D48F381B</xml_checksum>
   <class_name>ProcessVariableSpeedCentralAirConditioner</class_name>
   <display_name>Set Residential Variable-Speed Central Air Conditioner</display_name>
@@ -355,12 +355,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -373,154 +367,160 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACCentralAirConditionerVariableSpeed/resources/geometry.rb
+++ b/measures/ResidentialHVACCentralAirConditionerVariableSpeed/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACCoolingSetpoints/measure.xml
+++ b/measures/ResidentialHVACCoolingSetpoints/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_cooling_setpoints</name>
   <uid>2daa9d28-8891-4074-a1d1-bce3cb3d7ac6</uid>
-  <version_id>a5c61d26-25e5-4a1e-8527-3efaf3257774</version_id>
-  <version_modified>20181003T150227Z</version_modified>
+  <version_id>5ee4484d-eaf8-4675-836c-a79072b2b01a</version_id>
+  <version_modified>20181009T182541Z</version_modified>
   <xml_checksum>356BE47F</xml_checksum>
   <class_name>ProcessCoolingSetpoints</class_name>
   <display_name>Set Residential Cooling Setpoints and Schedules</display_name>
@@ -256,12 +256,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -274,70 +268,76 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BAA7E1D9</checksum>
+      <checksum>73F0F64A</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_ASHP_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9ED1580E</checksum>
+      <checksum>E0A725A2</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_CentralAC_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C86A1B63</checksum>
+      <checksum>05430874</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC_NoClgSetpoint.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>63353089</checksum>
+      <checksum>67F8588B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_GSHPVertBore_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>20CCA5AA</checksum>
+      <checksum>BD66ED4C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_RoomAC_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>CEB96DB0</checksum>
+      <checksum>F62E65F1</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0768058A</checksum>
+      <checksum>A685927B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_MSHP_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B256CF40</checksum>
+      <checksum>5EAED891</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_SL_UA_3Beds_2Baths_Denver_CentralAC_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F7E9467</checksum>
+      <checksum>66CFD20A</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_CentralAC_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>5F59377A</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>5F41806C</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACCoolingSetpoints/resources/geometry.rb
+++ b/measures/ResidentialHVACCoolingSetpoints/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACDehumidifier/measure.xml
+++ b/measures/ResidentialHVACDehumidifier/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_dehumidifier</name>
   <uid>f2d9e1e8-17bd-4a4a-a46b-df5f7e54e6c3</uid>
-  <version_id>cabf157d-9ac4-4ae4-a8f7-cd4939b00aa9</version_id>
-  <version_modified>20181003T150227Z</version_modified>
+  <version_id>18fb35ce-bd02-431a-ba73-ad00e17ade8a</version_id>
+  <version_modified>20181009T182541Z</version_modified>
   <xml_checksum>D48F381B</xml_checksum>
   <class_name>ProcessDehumidifier</class_name>
   <display_name>Set Residential Dehumidifier</display_name>
@@ -121,12 +121,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -139,28 +133,34 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACDehumidifier/resources/geometry.rb
+++ b/measures/ResidentialHVACDehumidifier/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACElectricBaseboard/measure.xml
+++ b/measures/ResidentialHVACElectricBaseboard/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_electric_baseboard</name>
   <uid>3ed9f2f9-5d0a-4115-ac5b-b11db9a5b02d</uid>
-  <version_id>3873fafb-6458-4b67-b7b5-d2eecac41260</version_id>
-  <version_modified>20181003T150227Z</version_modified>
+  <version_id>e74e3cbc-6112-4af7-902c-d7e058f1e5f5</version_id>
+  <version_modified>20181009T182542Z</version_modified>
   <xml_checksum>0DA5C9E6</xml_checksum>
   <class_name>ProcessElectricBaseboard</class_name>
   <display_name>Set Residential Electric Baseboard</display_name>
@@ -103,12 +103,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -121,148 +115,154 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACElectricBaseboard/resources/geometry.rb
+++ b/measures/ResidentialHVACElectricBaseboard/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACFurnace/measure.xml
+++ b/measures/ResidentialHVACFurnace/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_furnace</name>
   <uid>1a71ae9e-5485-4cca-a369-16c6b8a9c1d8</uid>
-  <version_id>caebc16c-02eb-4fd5-9df7-bf5255ec6456</version_id>
-  <version_modified>20181003T150228Z</version_modified>
+  <version_id>9019c8ef-eb1d-47d5-921e-6dad168376b6</version_id>
+  <version_modified>20181009T182542Z</version_modified>
   <xml_checksum>470FC630</xml_checksum>
   <class_name>ProcessFurnace</class_name>
   <display_name>Set Residential Furnace</display_name>
@@ -159,12 +159,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -177,148 +171,154 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACFurnace/resources/geometry.rb
+++ b/measures/ResidentialHVACFurnace/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACGroundSourceHeatPumpVerticalBore/measure.xml
+++ b/measures/ResidentialHVACGroundSourceHeatPumpVerticalBore/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_ground_source_heat_pump_vertical_bore</name>
   <uid>2151a447-b1d8-44dc-b297-90cb7e1223c1</uid>
-  <version_id>4f9566b0-4005-43a9-9a66-d033bdc3a409</version_id>
-  <version_modified>20181003T150228Z</version_modified>
+  <version_id>be3f8544-2db0-4e6e-8682-b7e9a0cfa3ab</version_id>
+  <version_modified>20181009T182542Z</version_modified>
   <xml_checksum>470FC630</xml_checksum>
   <class_name>ProcessGroundSourceHeatPumpVerticalBore</class_name>
   <display_name>Set Residential Ground Source Heat Pump Vertical Bore</display_name>
@@ -423,12 +423,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -441,154 +435,160 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E1E9508F</checksum>
+      <checksum>80C6E64E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACGroundSourceHeatPumpVerticalBore/resources/geometry.rb
+++ b/measures/ResidentialHVACGroundSourceHeatPumpVerticalBore/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACHeatingSetpoints/measure.xml
+++ b/measures/ResidentialHVACHeatingSetpoints/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_heating_setpoints</name>
   <uid>2b167665-f760-462d-8c9d-1d909da7b628</uid>
-  <version_id>75a2e08d-c846-4fc3-852c-515d90b3aafc</version_id>
-  <version_modified>20181003T150228Z</version_modified>
+  <version_id>acc1c838-adbc-4100-84d8-5064a43132f9</version_id>
+  <version_modified>20181009T182542Z</version_modified>
   <xml_checksum>2C877DEB</xml_checksum>
   <class_name>ProcessHeatingSetpoints</class_name>
   <display_name>Set Residential Heating Setpoints and Schedules</display_name>
@@ -246,12 +246,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -264,82 +258,88 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BAA7E1D9</checksum>
+      <checksum>73F0F64A</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_ASHP_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9ED1580E</checksum>
+      <checksum>E0A725A2</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_ElectricBaseboard_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B625A58</checksum>
+      <checksum>6E7A87C7</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_CentralAC_NoHtgSetpoint.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>8786975C</checksum>
+      <checksum>23B54DDB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Furnace_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3E914237</checksum>
+      <checksum>274575DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_GSHPVertBore_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>20CCA5AA</checksum>
+      <checksum>BD66ED4C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_Boiler_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>A6A3FA9D</checksum>
+      <checksum>2DFB53E9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0768058A</checksum>
+      <checksum>A685927B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_MSHP_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B256CF40</checksum>
+      <checksum>5EAED891</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_3Beds_2Baths_Denver_UnitHeater_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7FA35A73</checksum>
+      <checksum>46DDD3E1</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_SL_UA_3Beds_2Baths_Denver_Furnace_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>6C5AFDB4</checksum>
+      <checksum>0A254037</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_Furnace_NoSetpoints.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>92C95BC7</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>0AD8E906</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACHeatingSetpoints/resources/geometry.rb
+++ b/measures/ResidentialHVACHeatingSetpoints/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACMiniSplitHeatPump/measure.xml
+++ b/measures/ResidentialHVACMiniSplitHeatPump/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_vrf_minisplit</name>
   <uid>402b168f-ed99-46bb-b367-103937011e91</uid>
-  <version_id>bf30ceb5-2a24-442f-9fd6-bdf59bdcce17</version_id>
-  <version_modified>20181003T150228Z</version_modified>
+  <version_id>d0059e70-fb24-4fa2-ae9e-e0e11c2452b8</version_id>
+  <version_modified>20181009T182543Z</version_modified>
   <xml_checksum>470FC630</xml_checksum>
   <class_name>ProcessVRFMinisplit</class_name>
   <display_name>Set Residential Mini-Split Heat Pump</display_name>
@@ -310,12 +310,6 @@
       <checksum>09D68E83</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -328,148 +322,154 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACMiniSplitHeatPump/resources/geometry.rb
+++ b/measures/ResidentialHVACMiniSplitHeatPump/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACRoomAirConditioner/measure.xml
+++ b/measures/ResidentialHVACRoomAirConditioner/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_room_air_conditioner</name>
   <uid>eae61440-6574-4568-88d7-c735f9c3ea9f</uid>
-  <version_id>06c5c75a-f41a-4c03-a742-4041b6c47f5a</version_id>
-  <version_modified>20181003T150228Z</version_modified>
+  <version_id>c35355ac-c313-4c28-ad38-ab65b920c3dd</version_id>
+  <version_modified>20181009T182543Z</version_modified>
   <xml_checksum>D48F381B</xml_checksum>
   <class_name>ProcessRoomAirConditioner</class_name>
   <display_name>Set Residential Room Air Conditioner</display_name>
@@ -131,12 +131,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -149,148 +143,154 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACRoomAirConditioner/resources/geometry.rb
+++ b/measures/ResidentialHVACRoomAirConditioner/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACSizing/measure.xml
+++ b/measures/ResidentialHVACSizing/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_hvac_sizing</name>
   <uid>6cd70740-6ca3-4575-8b1e-663976e254d0</uid>
-  <version_id>c231e11b-cdfc-4bcc-9fce-98814e816227</version_id>
-  <version_modified>20181003T150229Z</version_modified>
+  <version_id>3fd3b994-3071-4980-990b-f5ebe6cb7122</version_id>
+  <version_modified>20181009T182543Z</version_modified>
   <xml_checksum>356BE47F</xml_checksum>
   <class_name>ProcessHVACSizing</class_name>
   <display_name>Set Residential HVAC Sizing</display_name>
@@ -154,12 +154,6 @@
       <checksum>972014A8</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -172,400 +166,406 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_HVACSizing_Load_2story_CS_GRG_FA_ASHP_DuctsInCS.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>8C7EAD84</checksum>
+      <checksum>A3242993</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_FB_GRG_FA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B9FEA3E9</checksum>
+      <checksum>EC4D69EE</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_CS_GRG_FA_ASHP_DuctsInLiv.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>76DBF35C</checksum>
+      <checksum>29605219</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_CS_GRG_FA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9252AC69</checksum>
+      <checksum>3E44F7D4</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_S_UA_Vented_Atlanta_ExtFinDark.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>62BA1361</checksum>
+      <checksum>4030AB04</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_S_UA_Vented_LosAngeles.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>19DFE82F</checksum>
+      <checksum>FB06671A</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_S_UA_Vented.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>ECC6E328</checksum>
+      <checksum>AAF88B81</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_CS_GRG_FA_ASHP_DuctsInGRG.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FF75D489</checksum>
+      <checksum>61C1E13D</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_S_UA_Unvented_NoOverhangs_NoIntShading_NoMechVent.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>76610073</checksum>
+      <checksum>FFC6F180</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_S_UA_Unvented_NoOverhangs_NoIntShading_SupplyMechVent.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B8616AE5</checksum>
+      <checksum>9C2E9C59</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_MSHP_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>59D0EAC2</checksum>
+      <checksum>983756D8</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_MSHP_BB_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B227B844</checksum>
+      <checksum>A39E0E4E</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_MSHP_AutosizeForMaxLoad.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D46C9E4C</checksum>
+      <checksum>0E23CE8D</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_MSHP_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D16AF303</checksum>
+      <checksum>0F6A1667</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_MSHP_BB_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1AADF876</checksum>
+      <checksum>4EC018C6</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_MSHPDucted_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E14A4343</checksum>
+      <checksum>F351E98C</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_UnitHeater_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3D65015F</checksum>
+      <checksum>D17074CE</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_UnitHeater_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>01839F59</checksum>
+      <checksum>63A16FF1</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_UnitHeater_Fixed_wFan.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9A50332B</checksum>
+      <checksum>13E95AEA</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_UnitHeater_AC1_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DB20D3BF</checksum>
+      <checksum>8964CB09</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_UnitHeater_AC1_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4388E847</checksum>
+      <checksum>A4C01C57</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GF_RAC_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3992F368</checksum>
+      <checksum>1A1CC296</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GF_AC1_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4459FE4B</checksum>
+      <checksum>B03AB7BF</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GF_RAC_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>202ADB66</checksum>
+      <checksum>7D4C6ADA</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GF_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>6945A784</checksum>
+      <checksum>AA15552C</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GF_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>EF827ACA</checksum>
+      <checksum>D695AB91</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GSHP_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>A5BEC668</checksum>
+      <checksum>5AF53562</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GSHP_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>02F117B9</checksum>
+      <checksum>75B12341</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GF_ACV_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FCF6FC0D</checksum>
+      <checksum>49D13623</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GF_ACV_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>A6EC873E</checksum>
+      <checksum>2AE1630E</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GF_AC1_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2570F182</checksum>
+      <checksum>6E1E0CB7</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_Dehumidifier_Auto_Atlanta.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>307D1BEA</checksum>
+      <checksum>97D3D377</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_Dehumidifier_Fixed_Atlanta.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>6D8C355E</checksum>
+      <checksum>12B31CF8</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ElecBoiler_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4EF6D4E5</checksum>
+      <checksum>267F6487</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ElecBoiler_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBCB1C80</checksum>
+      <checksum>A7732F97</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_EF_AC2_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>A378BFD5</checksum>
+      <checksum>4F0B0FD8</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_EF_AC2_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2DCB2B8C</checksum>
+      <checksum>7042782F</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GasBoiler_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1A57A755</checksum>
+      <checksum>5AEC2942</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_GasBoiler_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>64274DF0</checksum>
+      <checksum>2BE00FC9</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_S_UA_Unvented_InsRoof.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C674397A</checksum>
+      <checksum>6542B80B</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_PB_UA_Vented.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>F9B1FC5F</checksum>
+      <checksum>2451419F</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_PB_UA_Vented_ASHP_DuctsInPB.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>36BADB12</checksum>
+      <checksum>1593FAF6</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_PB_UA_Vented_ASHP_DuctsInUA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FFFFE050</checksum>
+      <checksum>BC9FB2DE</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_S_UA_Unvented_NoOverhangs_NoIntShading_ERV.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>97FFC7E1</checksum>
+      <checksum>A64C53E9</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_1story_S_UA_Unvented_NoOverhangs_NoIntShading_HRV.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>88492EA9</checksum>
+      <checksum>736ACCCB</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_BB_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7CAB87D2</checksum>
+      <checksum>D4D894CA</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_BB_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3454DBDC</checksum>
+      <checksum>4C81629A</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ASHP1_Autosize_MinTemp.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>451A1ED6</checksum>
+      <checksum>F51BC689</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ASHP1_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E361825E</checksum>
+      <checksum>D306F824</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ASHPV_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>015374F3</checksum>
+      <checksum>EB9FC9BD</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ASHP2_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B18906C3</checksum>
+      <checksum>46A4F35B</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ASHPV_Fixed.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>8796C814</checksum>
+      <checksum>17D27B00</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ASHP2_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>88608653</checksum>
+      <checksum>9F506915</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ASHP1_Autosize.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>568064FB</checksum>
+      <checksum>99587F98</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Equip_ASHP1_AutosizeForMaxLoad_MinTemp.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B2610F33</checksum>
+      <checksum>0B408EE3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E1E9508F</checksum>
+      <checksum>80C6E64E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFA_HVACSizing_Load_4units_1story_FB_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>A1DF5481</checksum>
+      <checksum>2CD328BA</checksum>
     </file>
     <file>
       <filename>MF_HVACSizing_Load_8units_1story_UB.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C166D533</checksum>
+      <checksum>AC282EAF</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_CS_GRG_FA_Skylights.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>613AFEF4</checksum>
+      <checksum>A89D587B</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_CS_GRG_FlatRoof_Skylights.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>86B33D4F</checksum>
+      <checksum>1D54D801</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_S_GRG_FA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DEAEE10C</checksum>
+      <checksum>A182927A</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_FB_GRG_FA_ASHP_DuctsInFB.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E1083AE8</checksum>
+      <checksum>7626C0BC</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_UB_GRG_FA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>62E00AF9</checksum>
+      <checksum>81459FBB</checksum>
     </file>
     <file>
       <filename>SFD_HVACSizing_Load_2story_UB_GRG_FA_ASHP_DuctsInUB.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>6C63EB29</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>1DA89B2C</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACSizing/resources/geometry.rb
+++ b/measures/ResidentialHVACSizing/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHVACUnitHeater/measure.xml
+++ b/measures/ResidentialHVACUnitHeater/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_unit_heater</name>
   <uid>1a71ae9e-5485-4cca-a369-16c6b8a9c1d8</uid>
-  <version_id>3cf719ef-d3cb-4f95-8d12-cdabb41ef23c</version_id>
-  <version_modified>20181003T150229Z</version_modified>
+  <version_id>dcaf7d49-bee9-4901-aa4d-6ce0c808d6ab</version_id>
+  <version_modified>20181009T182544Z</version_modified>
   <xml_checksum>470FC630</xml_checksum>
   <class_name>ProcessUnitHeater</class_name>
   <display_name>Set Residential Unit Heater</display_name>
@@ -148,12 +148,6 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -166,154 +160,160 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_MSHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>40E298A0</checksum>
+      <checksum>36D6D181</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FC11B437</checksum>
+      <checksum>FC6125E5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96E05E7D</checksum>
+      <checksum>4E5CAFF3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4BE658EE</checksum>
+      <checksum>9A3DDCA3</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_UnitHeater_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9359C75C</checksum>
+      <checksum>6AE93228</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E377F39C</checksum>
+      <checksum>D75474D9</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B727FCD0</checksum>
+      <checksum>4C27B894</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D1FFC9C6</checksum>
+      <checksum>0623662B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0F9779AE</checksum>
+      <checksum>41AC90F0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Furnace_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>170D364B</checksum>
+      <checksum>3FC3D6DA</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_GSHPVertBore.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B614FAE9</checksum>
+      <checksum>64F9E597</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>DBB6F096</checksum>
+      <checksum>8A05F53E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_CentralAC2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04F5E956</checksum>
+      <checksum>DA518D34</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FBAFE9D6</checksum>
+      <checksum>ECF341CD</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ElectricBaseboard_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E53FD698</checksum>
+      <checksum>348BD4CC</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_CentralAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>21880158</checksum>
+      <checksum>B6E5E346</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler_RoomAC.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE47A555</checksum>
+      <checksum>C4ACDBF0</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2E25DC01</checksum>
+      <checksum>D94CDD5E</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>E0354D50</checksum>
+      <checksum>D06B9518</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_ASHP2.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2B581AFF</checksum>
+      <checksum>1627F568</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_UA_Denver_Boiler.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3AD3C6EA</checksum>
+      <checksum>820BE06C</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHVACUnitHeater/resources/geometry.rb
+++ b/measures/ResidentialHVACUnitHeater/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHotWaterDistribution/measure.xml
+++ b/measures/ResidentialHotWaterDistribution/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_hot_water_distribution</name>
   <uid>4615ccb7-3ce5-4627-b7c2-a7fea9c4af87</uid>
-  <version_id>f0af4093-1490-46f2-a814-b9e724c9d6f1</version_id>
-  <version_modified>20181003T150224Z</version_modified>
+  <version_id>e8f4d4dc-2573-466c-9b5b-59460ba0c9fc</version_id>
+  <version_modified>20181009T182538Z</version_modified>
   <xml_checksum>D2231FB9</xml_checksum>
   <class_name>ResidentialHotWaterDistribution</class_name>
   <display_name>Set Residential Hot Water Distribution</display_name>
@@ -281,58 +281,58 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_HWFixtures.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7089811F</checksum>
+      <checksum>C203BFAB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>002D13D0</checksum>
+      <checksum>4227BD92</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2C93F17D</checksum>
+      <checksum>3B6B17B5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>08F3C449</checksum>
+      <checksum>CD9E7AE8</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver_WHTank_HWFixtures.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7A4201D9</checksum>
+      <checksum>52615BA3</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_WHTank_HWFixtures.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0993E0F9</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>817199F7</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHotWaterDistribution/resources/geometry.rb
+++ b/measures/ResidentialHotWaterDistribution/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHotWaterFixtures/measure.xml
+++ b/measures/ResidentialHotWaterFixtures/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_hot_water_fixtures</name>
   <uid>6159fd36-6bfa-4907-9200-9cb852d50799</uid>
-  <version_id>822a952b-6935-4d30-8cd1-252cb9ca122a</version_id>
-  <version_modified>20181003T150224Z</version_modified>
+  <version_id>b85423a3-0d37-4ad7-bdd1-4fa90e467441</version_id>
+  <version_modified>20181009T182539Z</version_modified>
   <xml_checksum>A6ACD89C</xml_checksum>
   <class_name>ResidentialHotWaterFixtures</class_name>
   <display_name>Set Residential Hot Water Fixtures</display_name>
@@ -242,52 +242,52 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_HWFixtures_RecircDist.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>52B4EADB</checksum>
+      <checksum>3FD7115B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F55039A</checksum>
+      <checksum>72FFE927</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>08F3C449</checksum>
+      <checksum>CD9E7AE8</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE9C3C0E</checksum>
+      <checksum>61BE628A</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BDC0A200</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>EBC562C9</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHotWaterFixtures/resources/geometry.rb
+++ b/measures/ResidentialHotWaterFixtures/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHotWaterHeaterHeatPump/measure.xml
+++ b/measures/ResidentialHotWaterHeaterHeatPump/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_hot_water_heater_heat_pump</name>
   <uid>cfbe1e78-78db-4902-aba3-95d23310802e</uid>
-  <version_id>a5f90edb-ea73-4766-9662-c4f252e4185c</version_id>
-  <version_modified>20181003T150225Z</version_modified>
+  <version_id>9aa138bd-0bee-465b-a46f-b76b16437f1f</version_id>
+  <version_modified>20181009T182539Z</version_modified>
   <xml_checksum>9882CBDB</xml_checksum>
   <class_name>ResidentialHotWaterHeaterHeatPump</class_name>
   <display_name>Set Residential Heat Pump Water Heater</display_name>
@@ -247,88 +247,88 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTankless_SHW.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>3646A8A3</checksum>
+      <checksum>A394B2DE</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_SHW.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>EFAC4DDA</checksum>
+      <checksum>48EEA87F</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F55039A</checksum>
+      <checksum>72FFE927</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2C93F17D</checksum>
+      <checksum>3B6B17B5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_OilWHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7EDF5E1C</checksum>
+      <checksum>4AF07AFF</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_HPWH.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96CCAA19</checksum>
+      <checksum>C6FE23A8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_HPWH_SHW.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>CBCE358F</checksum>
+      <checksum>72919F93</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>08F3C449</checksum>
+      <checksum>CD9E7AE8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTankless.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7AA30BD7</checksum>
+      <checksum>6105A249</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D49235FC</checksum>
+      <checksum>E04DAF60</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1B63556F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>3A8AE4C3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHotWaterHeaterHeatPump/resources/geometry.rb
+++ b/measures/ResidentialHotWaterHeaterHeatPump/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHotWaterHeaterTank/measure.xml
+++ b/measures/ResidentialHotWaterHeaterTank/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_hot_water_heater_tank</name>
   <uid>0f2214ac-12ca-4350-9942-8d1fb1277608</uid>
-  <version_id>bfdc9a83-3880-447f-800c-3bfb35ce774e</version_id>
-  <version_modified>20181003T150225Z</version_modified>
+  <version_id>847ed2bb-696b-4ce3-9644-dfcedc6e3786</version_id>
+  <version_modified>20181009T182539Z</version_modified>
   <xml_checksum>9882CBDB</xml_checksum>
   <class_name>ResidentialHotWaterHeaterTank</class_name>
   <display_name>Set Residential Tank Water Heater</display_name>
@@ -212,64 +212,64 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_SHW.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>EFAC4DDA</checksum>
+      <checksum>48EEA87F</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F55039A</checksum>
+      <checksum>72FFE927</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2C93F17D</checksum>
+      <checksum>3B6B17B5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_HPWH.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96CCAA19</checksum>
+      <checksum>C6FE23A8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTankless.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7AA30BD7</checksum>
+      <checksum>6105A249</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D49235FC</checksum>
+      <checksum>E04DAF60</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1B63556F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>3A8AE4C3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHotWaterHeaterTank/resources/geometry.rb
+++ b/measures/ResidentialHotWaterHeaterTank/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHotWaterHeaterTankless/measure.xml
+++ b/measures/ResidentialHotWaterHeaterTankless/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_hot_water_heater_tankless</name>
   <uid>caf92375-4c0c-47d1-9fe1-7aa5d3b1a734</uid>
-  <version_id>10a3bfec-9475-419a-be75-13b0c2505eb0</version_id>
-  <version_modified>20181003T150225Z</version_modified>
+  <version_id>9e1714de-0d90-468a-924d-89dd86873b7d</version_id>
+  <version_modified>20181009T182539Z</version_modified>
   <xml_checksum>9882CBDB</xml_checksum>
   <class_name>ResidentialHotWaterHeaterTankless</class_name>
   <display_name>Set Residential Tankless Water Heater</display_name>
@@ -198,64 +198,64 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank_SHW.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>EFAC4DDA</checksum>
+      <checksum>48EEA87F</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F55039A</checksum>
+      <checksum>72FFE927</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2C93F17D</checksum>
+      <checksum>3B6B17B5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_HPWH.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96CCAA19</checksum>
+      <checksum>C6FE23A8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>08F3C449</checksum>
+      <checksum>CD9E7AE8</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D49235FC</checksum>
+      <checksum>E04DAF60</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1B63556F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>3A8AE4C3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHotWaterHeaterTankless/resources/geometry.rb
+++ b/measures/ResidentialHotWaterHeaterTankless/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialHotWaterSolar/measure.xml
+++ b/measures/ResidentialHotWaterSolar/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_hot_water_solar</name>
   <uid>b969f216-f3c0-4301-9b85-34ce2b45f551</uid>
-  <version_id>8cf71b3d-27a2-47ad-8fbc-b2268e44d020</version_id>
-  <version_modified>20181003T150225Z</version_modified>
+  <version_id>9226c14b-df4b-46d7-a104-880e7e0a2a24</version_id>
+  <version_modified>20181009T182539Z</version_modified>
   <xml_checksum>F33F6E26</xml_checksum>
   <class_name>ResidentialHotWaterSolar</class_name>
   <display_name>Set Residential Solar Water Heating</display_name>
@@ -248,12 +248,6 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -266,64 +260,70 @@
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>2C93F17D</checksum>
+      <checksum>3B6B17B5</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_East_GasWHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>61CF139A</checksum>
+      <checksum>DD03C3C4</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_HPWH.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>96CCAA19</checksum>
+      <checksum>C6FE23A8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_West_GasWHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>5A622D57</checksum>
+      <checksum>33AE712F</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_South_GasWHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>B39103A9</checksum>
+      <checksum>0C6768A8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>08F3C449</checksum>
+      <checksum>CD9E7AE8</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths_Denver_WHTankless.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7AA30BD7</checksum>
+      <checksum>6105A249</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>AE9C3C0E</checksum>
+      <checksum>61BE628A</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver_WHTank.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>BDC0A200</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>EBC562C9</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialHotWaterSolar/resources/geometry.rb
+++ b/measures/ResidentialHotWaterSolar/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialLighting/measure.xml
+++ b/measures/ResidentialLighting/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_lighting</name>
   <uid>82efbdfd-258d-421a-8c32-ff4636bea099</uid>
-  <version_id>3e4b65ed-49a7-430b-a709-1a6e09657c8b</version_id>
-  <version_modified>20181003T150230Z</version_modified>
+  <version_id>094b63fd-ff3b-4e76-b6df-f93d0dbe62cd</version_id>
+  <version_modified>20181009T182544Z</version_modified>
   <xml_checksum>2DDDDD82</xml_checksum>
   <class_name>ResidentialLighting</class_name>
   <display_name>Set Residential Lighting</display_name>
@@ -250,52 +250,52 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_Anchorage.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>87497A0B</checksum>
+      <checksum>453FCBFE</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>65578016</checksum>
+      <checksum>CD269FB7</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>002D13D0</checksum>
+      <checksum>4227BD92</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialLighting/resources/geometry.rb
+++ b/measures/ResidentialLighting/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialMiscLargeUncommonLoads/measure.xml
+++ b/measures/ResidentialMiscLargeUncommonLoads/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_misc_large_uncommon_loads</name>
   <uid>96f1e9ca-41b9-4fb8-a219-57850e351500</uid>
-  <version_id>011a320c-b36d-4709-a4a3-8d63bca63c44</version_id>
-  <version_modified>20181003T150230Z</version_modified>
+  <version_id>24c2e647-9288-45c7-bd61-259949b7db4f</version_id>
+  <version_modified>20181009T182544Z</version_modified>
   <xml_checksum>126F1C43</xml_checksum>
   <class_name>ResidentialMiscLargeUncommonLoads</class_name>
   <display_name>Set Residential Large Uncommon Loads</display_name>
@@ -896,46 +896,46 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F55039A</checksum>
+      <checksum>72FFE927</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_UB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>4FA2C21D</checksum>
+      <checksum>12ED99F2</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D49235FC</checksum>
+      <checksum>E04DAF60</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1B63556F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>3A8AE4C3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialMiscLargeUncommonLoads/resources/geometry.rb
+++ b/measures/ResidentialMiscLargeUncommonLoads/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialMiscPlugLoads/measure.xml
+++ b/measures/ResidentialMiscPlugLoads/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_misc_electric_loads</name>
   <uid>3ac41688-ef52-4679-b79c-8cbdf7cbd0e7</uid>
-  <version_id>fbf8315d-390f-4ab8-b827-3f2eadaa67fa</version_id>
-  <version_modified>20181003T150230Z</version_modified>
+  <version_id>62f6269b-1e2a-44e8-b778-821c2721e965</version_id>
+  <version_modified>20181009T182544Z</version_modified>
   <xml_checksum>126F1C43</xml_checksum>
   <class_name>ResidentialMiscElectricLoads</class_name>
   <display_name>Set Residential Plug Loads</display_name>
@@ -148,40 +148,40 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
-    </file>
-    <file>
       <filename>schedules.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>4C000237</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>62B9E41C</checksum>
+    </file>
+    <file>
       <filename>SFD_2000sqft_2story_FB_GRG_UA_3Beds_2Baths.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>7F55039A</checksum>
+      <checksum>72FFE927</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>D49235FC</checksum>
+      <checksum>E04DAF60</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_3Beds_2Baths_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>1B63556F</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>3A8AE4C3</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialMiscPlugLoads/resources/geometry.rb
+++ b/measures/ResidentialMiscPlugLoads/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/ResidentialPhotovoltaics/measure.xml
+++ b/measures/ResidentialPhotovoltaics/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>residential_photovoltaics</name>
   <uid>3ed7d5e0-4441-43d9-a47e-ae4560a6db92</uid>
-  <version_id>04513d12-cb9e-4de2-be71-21234135f52c</version_id>
-  <version_modified>20181003T150230Z</version_modified>
+  <version_id>553d46a5-719c-4dbc-b7c7-2f0eca81c2b8</version_id>
+  <version_modified>20181009T182544Z</version_modified>
   <xml_checksum>1BFC8ABF</xml_checksum>
   <class_name>ResidentialPhotovoltaics</class_name>
   <display_name>Set Residential Photovoltaics</display_name>
@@ -220,52 +220,52 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>geometry.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>B237D248</checksum>
+      <checksum>62B9E41C</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver_North.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>81E2B703</checksum>
+      <checksum>62C01F5B</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver_West.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>523C8608</checksum>
+      <checksum>4F43F588</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>567B0ED9</checksum>
+      <checksum>E0C9E9EB</checksum>
     </file>
     <file>
       <filename>SFD_2000sqft_2story_SL_UA_Denver_East.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>9A5EAA6F</checksum>
+      <checksum>48DFE1F4</checksum>
     </file>
     <file>
       <filename>SFA_4units_1story_FB_UA_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>FADB3A65</checksum>
+      <checksum>0647E240</checksum>
     </file>
     <file>
       <filename>MF_8units_1story_SL_Denver.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>C8DFA1D8</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>4229FB7D</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ResidentialPhotovoltaics/resources/geometry.rb
+++ b/measures/ResidentialPhotovoltaics/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)

--- a/measures/TimeseriesCSVExport/measure.xml
+++ b/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>e8498083-e6bf-422c-ba79-bd6a458ff72b</version_id>
-  <version_modified>20181003T150231Z</version_modified>
+  <version_id>10c337fa-c703-4314-a92d-048ac0da9bc6</version_id>
+  <version_modified>20181009T182544Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -162,22 +162,22 @@
       <checksum>454E14D4</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>SFD_Successful_EnergyPlus_Run_AMY_PV.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>31C56C1E</checksum>
+      <checksum>9594C0EC</checksum>
     </file>
     <file>
       <filename>SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>0A84A2C9</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>44EE285A</checksum>
     </file>
   </files>
 </measure>

--- a/measures/UtilityBillCalculationsDetailed/measure.xml
+++ b/measures/UtilityBillCalculationsDetailed/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>utility_bill_calculations_detailed</name>
   <uid>1d640acd-1a68-49cb-91f0-f3a65dbe40a7</uid>
-  <version_id>702cb2bc-ec44-4838-9d1b-1b01b9acac1f</version_id>
-  <version_modified>20181003T150231Z</version_modified>
+  <version_id>860fd46a-184e-494c-9680-3f6f167b97a7</version_id>
+  <version_modified>20181009T182545Z</version_modified>
   <xml_checksum>6159342E</xml_checksum>
   <class_name>UtilityBillCalculationsDetailed</class_name>
   <display_name>Calculate Detailed Utility Bills</display_name>
@@ -18747,22 +18747,22 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>SFD_Successful_EnergyPlus_Run_AMY_PV.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>31C56C1E</checksum>
+      <checksum>9594C0EC</checksum>
     </file>
     <file>
       <filename>SFD_Successful_EnergyPlus_Run_TMY_PV.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04A17EE9</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>FB6F10DA</checksum>
     </file>
   </files>
 </measure>

--- a/measures/UtilityBillCalculationsSimple/measure.xml
+++ b/measures/UtilityBillCalculationsSimple/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>utility_bill_calculations_simple</name>
   <uid>872cd20c-55df-459e-9ac9-f42c93ab665c</uid>
-  <version_id>a2443257-b6af-4244-8e25-4ca9451d1970</version_id>
-  <version_modified>20181003T150235Z</version_modified>
+  <version_id>61eb6a91-61da-4a3d-8f15-a8171297d9dc</version_id>
+  <version_modified>20181009T182548Z</version_modified>
   <xml_checksum>6159342E</xml_checksum>
   <class_name>UtilityBillCalculationsSimple</class_name>
   <display_name>Calculate Simple Utility Bills</display_name>
@@ -254,22 +254,22 @@
       <checksum>81550F14</checksum>
     </file>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>C6878D1E</checksum>
+    </file>
+    <file>
       <filename>SFD_Successful_EnergyPlus_Run_AMY_PV.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>31C56C1E</checksum>
+      <checksum>9594C0EC</checksum>
     </file>
     <file>
       <filename>SFD_Successful_EnergyPlus_Run_TMY_PV.osm</filename>
       <filetype>osm</filetype>
       <usage_type>test</usage_type>
-      <checksum>04A17EE9</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>C6878D1E</checksum>
+      <checksum>FB6F10DA</checksum>
     </file>
   </files>
 </measure>

--- a/resources/geometry.rb
+++ b/resources/geometry.rb
@@ -756,7 +756,6 @@ class Geometry
   def self.get_walls_connected_to_floor(wall_surfaces, floor_surface)
       adjacent_wall_surfaces = []
       
-      # Note: Algorithm assumes that walls span an entire edge of the floor.
       wall_surfaces.each do |wall_surface|
           next if wall_surface.space.get != floor_surface.space.get
           wall_vertices = wall_surface.vertices
@@ -765,17 +764,17 @@ class Geometry
               floor_vertices = floor_surface.vertices
               floor_vertices.each_with_index do |fv1, fidx|
                   fv2 = floor_vertices[fidx-1]
-                  # Identical edge?
-                  if self.equal_vertices([wv1.x, wv1.y, 0], [fv1.x, fv1.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv2.x, fv2.y, 0])
-                      adjacent_wall_surfaces << wall_surface
-                  elsif self.equal_vertices([wv1.x, wv1.y, 0], [fv2.x, fv2.y, 0]) and self.equal_vertices([wv2.x, wv2.y, 0], [fv1.x, fv1.y, 0])
-                      adjacent_wall_surfaces << wall_surface
+                  # Wall within floor edge?
+                  if self.is_point_between([wv1.x, wv1.y, wv1.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z]) and self.is_point_between([wv2.x, wv2.y, wv2.z], [fv1.x, fv1.y, fv1.z], [fv2.x, fv2.y, fv2.z])
+                      if not adjacent_wall_surfaces.include? wall_surface
+                          adjacent_wall_surfaces << wall_surface
+                      end
                   end
               end
           end
       end
       
-      return adjacent_wall_surfaces.uniq!
+      return adjacent_wall_surfaces
   end
 
   def self.is_living(space_or_zone)


### PR DESCRIPTION
MF buildings with an odd number of units per floor would not get a wall correctly associated with a floor surface.