### PR TITLE
Duct frac_oa

### DIFF
--- a/measures/ResidentialAirflow/resources/airflow.rb
+++ b/measures/ResidentialAirflow/resources/airflow.rb
@@ -1121,7 +1121,7 @@ class Airflow
 
     total_unbalance = (supply_loss - return_loss).abs
 
-    if not location_name == unit_living.zone.name.to_s and not location_name == "none" and supply_loss > 0
+    if not location_name == unit_living.zone.name.to_s and not location_name == "none"
       # Calculate d.frac_oa = fraction of unbalanced make-up air that is outside air
       if total_unbalance <=  0
         # Handle the exception for if there is no leakage unbalance.

--- a/resources/airflow.rb
+++ b/resources/airflow.rb
@@ -1121,7 +1121,7 @@ class Airflow
 
     total_unbalance = (supply_loss - return_loss).abs
 
-    if not location_name == unit_living.zone.name.to_s and not location_name == "none" and supply_loss > 0
+    if not location_name == unit_living.zone.name.to_s and not location_name == "none"
       # Calculate d.frac_oa = fraction of unbalanced make-up air that is outside air
       if total_unbalance <=  0
         # Handle the exception for if there is no leakage unbalance.


### PR DESCRIPTION
Improve determination of duct model frac_oa when there is no supply duct leakage (only return leakage). Previous code was to workaround limitations in DOE2 that no longer apply.